### PR TITLE
fix: prevent duplicate logging of IP and DNS blacklist loading messages

### DIFF
--- a/ratelimiter.go
+++ b/ratelimiter.go
@@ -18,19 +18,20 @@ type RateLimit struct {
 	Requests        int              `json:"requests"`
 	Window          time.Duration    `json:"window"`
 	CleanupInterval time.Duration    `json:"cleanup_interval"`
-	Paths           []string         `json:"paths,omitempty"` // New: optional paths to apply rate limit
-	PathRegexes     []*regexp.Regexp `json:"-"`               // New: compiled regexes for the given paths
+	Paths           []string         `json:"paths,omitempty"` // Optional paths to apply rate limit
+	PathRegexes     []*regexp.Regexp `json:"-"`               // Compiled regexes for the given paths
 	MatchAllPaths   bool             `json:"match_all_paths,omitempty"`
 }
 
 // RateLimiter struct
 type RateLimiter struct {
 	sync.RWMutex
-	requests    map[string]map[string]*requestCounter // New: nested map for path-based rate limiting
+	requests    map[string]map[string]*requestCounter // Nested map for path-based rate limiting
 	config      RateLimit
 	stopCleanup chan struct{} // Channel to signal cleanup goroutine to stop
 }
 
+// NewRateLimiter creates a new RateLimiter instance.
 func NewRateLimiter(config RateLimit) *RateLimiter {
 	// Compile path regexes if paths are provided
 	if len(config.Paths) > 0 {
@@ -45,8 +46,9 @@ func NewRateLimiter(config RateLimit) *RateLimiter {
 	}
 
 	return &RateLimiter{
-		requests: make(map[string]map[string]*requestCounter),
-		config:   config,
+		requests:    make(map[string]map[string]*requestCounter),
+		config:      config,
+		stopCleanup: make(chan struct{}), // Initialize the stopCleanup channel
 	}
 }
 
@@ -63,7 +65,7 @@ func (rl *RateLimiter) isRateLimited(ip, path string) bool {
 	}
 
 	// Check if the path matches any of the configured paths
-	if len(rl.config.PathRegexes) > 0 {
+	if len(rl.config.PathRegexes) > 0 && !rl.config.MatchAllPaths {
 		matched := false
 		for _, regex := range rl.config.PathRegexes {
 			if regex.MatchString(path) {
@@ -71,7 +73,7 @@ func (rl *RateLimiter) isRateLimited(ip, path string) bool {
 				break
 			}
 		}
-		if !matched && !rl.config.MatchAllPaths {
+		if !matched {
 			return false // Path does not match any configured paths, no rate limiting
 		}
 	}
@@ -98,47 +100,32 @@ func (rl *RateLimiter) isRateLimited(ip, path string) bool {
 // cleanupExpiredEntries removes expired entries from the rate limiter.
 func (rl *RateLimiter) cleanupExpiredEntries() {
 	now := time.Now()
-	var expiredIPs []string
 
-	// Collect expired IPs to delete (read lock)
-	rl.RLock()
+	rl.Lock()
+	defer rl.Unlock()
+
 	for ip, pathCounters := range rl.requests {
 		for path, counter := range pathCounters {
 			if now.Sub(counter.window) > rl.config.Window {
-				expiredIPs = append(expiredIPs, ip)
 				delete(pathCounters, path)
 			}
 		}
 		if len(pathCounters) == 0 {
-			expiredIPs = append(expiredIPs, ip)
-		}
-	}
-	rl.RUnlock()
-
-	// Delete expired IPs (write lock)
-	if len(expiredIPs) > 0 {
-		rl.Lock()
-		for _, ip := range expiredIPs {
 			delete(rl.requests, ip)
 		}
-		rl.Unlock()
 	}
 }
 
 // startCleanup starts the goroutine to periodically clean up expired entries.
 func (rl *RateLimiter) startCleanup() {
-	// Ensure stopCleanup channel is created only once
-	if rl.stopCleanup == nil {
-		rl.stopCleanup = make(chan struct{})
-	}
-
 	go func() {
-		log.Println("[INFO] Starting rate limiter cleanup goroutine") // Added logging
-		ticker := time.NewTicker(rl.config.CleanupInterval)           // Use the specified cleanup interval
+		// log.Println("[INFO] Starting rate limiter cleanup goroutine")
+		ticker := time.NewTicker(rl.config.CleanupInterval)
 		defer func() {
 			ticker.Stop()
-			log.Println("[INFO] Rate limiter cleanup goroutine stopped") // Added logging on exit
+			// log.Println("[INFO] Rate limiter cleanup goroutine stopped")
 		}()
+
 		for {
 			select {
 			case <-ticker.C:
@@ -152,10 +139,12 @@ func (rl *RateLimiter) startCleanup() {
 
 // signalStopCleanup signals the cleanup goroutine to stop.
 func (rl *RateLimiter) signalStopCleanup() {
+	rl.Lock()
+	defer rl.Unlock()
+
 	if rl.stopCleanup != nil {
-		log.Println("[INFO] Signaling rate limiter cleanup goroutine to stop") // Added logging
+		log.Println("[INFO] Signaling rate limiter cleanup goroutine to stop")
 		close(rl.stopCleanup)
-		// We avoid setting rl.stopCleanup to nil here for maximum safety.
-		// Subsequent calls to signalStopCleanup will still be protected by the nil check.
+		rl.stopCleanup = nil // Prevent double-closing
 	}
 }


### PR DESCRIPTION
- Removed blacklist loading from `loadRules` to avoid duplicate logging.
- Ensured blacklists are loaded only once during the `Provision` method.
- Updated logging to provide consistent and clear context for debugging.