### PR TITLE
Potential fix for code scanning alert no. 41: Size computation for allocation may overflow

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -89,6 +89,11 @@ func (m *Middleware) extractLogIDField(fields []zap.Field) (logID string, remain
 
 // mergeFields merges custom fields and common fields, with custom fields taking precedence and ensuring log_id is present.
 func (m *Middleware) mergeFields(customFields []zap.Field, commonFields []zap.Field, logIDField zap.Field) []zap.Field {
+	// Check for potential overflow
+	if len(customFields) > (int(^uint(0) >> 1) - len(commonFields) - 1) {
+		m.logger.Error("Field lengths too large, potential overflow detected")
+		return nil
+	}
 	mergedFields := make([]zap.Field, 0, len(customFields)+len(commonFields)+1) //预分配容量
 	mergedFields = append(mergedFields, customFields...)
 


### PR DESCRIPTION
Potential fix for [https://github.com/fabriziosalmi/caddy-waf/security/code-scanning/41](https://github.com/fabriziosalmi/caddy-waf/security/code-scanning/41)

To fix the problem, we need to ensure that the arithmetic operation involving the lengths of the slices does not overflow. This can be achieved by validating the lengths of the slices before performing the arithmetic operation. Specifically, we should check if the sum of the lengths of `customFields` and `commonFields` exceeds the maximum value for the type before using it in the allocation.

1. Add a check to validate the lengths of `customFields` and `commonFields` before performing the arithmetic operation.
2. If the combined length exceeds the maximum value for the type, handle the error appropriately (e.g., by logging an error message and returning an error).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
