### PR TITLE
fix: do not append cidr notation subnet mask to ips that already have a cidr notation subnet mask

### DIFF
--- a/caddywaf.go
+++ b/caddywaf.go
@@ -498,7 +498,15 @@ func (m *Middleware) loadIPBlacklist(path string, blacklistMap iptrie.Trie) erro
 
 	// Convert the map to CIDRTrie
 	for ip := range blacklist {
-		prefix, err := netip.ParsePrefix(appendCIDR(ip))
+		var prefix netip.Prefix
+		var err error
+
+		if strings.Contains(ip, "/") {
+			prefix, err = netip.ParsePrefix(ip)
+		} else {
+			prefix, err = netip.ParsePrefix(appendCIDR(ip))
+		}
+
 		if err != nil {
 			m.logger.Warn("Skipping invalid IP in blacklist", zap.String("ip", ip), zap.Error(err))
 			continue

--- a/helpers.go
+++ b/helpers.go
@@ -33,7 +33,7 @@ func appendCIDR(ip string) string {
 		ip += "/32"
 		// IPv6
 	} else {
-		ip += "/64"
+		ip += "/128"
 	}
 	return ip
 }


### PR DESCRIPTION
fix: do not append cidr notation subnet mask to ips that already have a cidr notation subnet mask

Context: We would like to use `caddy-waf` to block entire IP subnets, defined in CIDR notation. Currently when doing so, and warning occurs because a `/32` is added to the end of the IPs that already contain CIDR notation (or a `/64` in the case of IPv6). 

The warning: `WARN    Skipping invalid IP in blacklist        {"ip": "144.86.173.0/24", "error": "netip.ParsePrefix(\"144.86.173.0/24/32\"): ParseAddr(\"144.86.173.0/24\"): unexpected character (at \"/24\")"}` 

I've opened this PR to address that, but fully acknowledge that I am not a developer, let alone a golang developer, so this may not be the ideal way do to so. If this is not the ideal way, I welcome feedback to improve my own skills. Thank you for your consideration.