### PR TITLE
docs: refresh SECURITY.md supported versions and reporting channel

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,13 @@
 
 ## Supported Versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| v0.1.x  | :white_check_mark: |
-| < 0.1.0 | :x:                |
+Only the latest release receives security fixes. There are no maintained
+backport branches: a fix ships in a new patch release off `main`.
+
+| Version  | Supported          |
+| -------- | ------------------ |
+| v0.3.4   | :white_check_mark: |
+| < v0.3.4 | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -15,8 +18,12 @@ We take the security of `caddy-waf` seriously. If you find a vulnerability, plea
 
 Please do **NOT** open a public issue on GitHub. Instead, report the vulnerability via:
 
-1.  **Email**: Send the details to the maintainer (fabrizio.salmi@gmail.com).
-2.  **GitHub Private Advisory**: Open a private advisory draft on this repository if you have permissions, or contact the maintainer to enable it.
+1.  **GitHub private vulnerability reporting** (preferred): use the
+    [Report a vulnerability](https://github.com/fabriziosalmi/caddy-waf/security/advisories/new)
+    button under the repository's Security tab. Private reporting is enabled, so
+    this works for anyone — no special permissions needed — and keeps the report
+    and the discussion private until an advisory is published.
+2.  **Email**: send the details to the maintainer (fabrizio.salmi@gmail.com).
 
 ### Required Information
 


### PR DESCRIPTION
Follow-up to the v0.3.4 security release (GHSA-gfj3-cmff-q8wh).

- The supported-versions table still claimed `v0.1.x`, which is misleading now that security fixes ship on `v0.3.x`. Replaced with the actual policy: only the latest release is patched, no backport branches.
- Reporting instructions now put **GitHub private vulnerability reporting** first, with a direct link. It is enabled on this repository (`GET /repos/.../private-vulnerability-reporting` → `{"enabled":true}`), so it works for anyone; the previous wording implied it required permissions and led with email instead.

Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)