### PR TITLE
docs: give the site a restrained visual identity

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,101 @@
+/*
+ * caddy-waf docs theme.
+ *
+ * Deliberately small. Every major VitePress site does the same handful of
+ * things -- override the brand colour triple, add one signature touch on the
+ * hero, soften the default shadows -- and leaves the rest of the theme alone.
+ * Restraint is what keeps it from looking like a template with decorations
+ * bolted on.
+ *
+ * Colours sit in the blue-cyan band: it reads as network infrastructure rather
+ * than alarm. Red is reserved for the one thing that should actually alarm the
+ * reader (the danger container), so it keeps its meaning.
+ *
+ * Every value below was checked for WCAG contrast rather than picked by eye.
+ * Ratios are noted inline; all beat VitePress's own default (4.48:1).
+ */
+
+:root {
+  /* brand-1 links, brand-2 hover, brand-3 solid button background. */
+  --vp-c-brand-1: #075985; /* 7.56:1 on white */
+  --vp-c-brand-2: #0e7490; /* 5.36:1 */
+  --vp-c-brand-3: #0369a1; /* 5.93:1 behind white button text */
+  --vp-c-brand-soft: rgba(3, 105, 161, 0.14);
+
+  /* Tip containers inherit the brand, so they follow automatically. */
+  --vp-c-tip-1: var(--vp-c-brand-1);
+  --vp-c-tip-2: var(--vp-c-brand-2);
+  --vp-c-tip-3: var(--vp-c-brand-3);
+  --vp-c-tip-soft: var(--vp-c-brand-soft);
+
+  /*
+   * The one signature element: a gradient on the product name in the hero.
+   * Kept dark enough to clear 3:1 as large text -- the usual mistake here is a
+   * pastel gradient that looks good in a screenshot and is unreadable in use.
+   */
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: linear-gradient(120deg, #075985 20%, #0891b2);
+
+  /* Softer than stock, which is heavy against light backgrounds. */
+  --vp-shadow-1: 0 1px 2px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.06);
+  --vp-shadow-2: 0 3px 12px rgba(0, 0, 0, 0.07);
+  --vp-shadow-3: 0 12px 32px rgba(0, 0, 0, 0.1);
+}
+
+.dark {
+  --vp-c-brand-1: #38bdf8; /* 8.01:1 on #1b1b1f */
+  --vp-c-brand-2: #7dd3fc; /* 10.30:1 */
+  --vp-c-brand-3: #0369a1; /* 5.93:1 behind white button text */
+  --vp-c-brand-soft: rgba(56, 189, 248, 0.16);
+
+  --vp-home-hero-name-background: linear-gradient(120deg, #38bdf8 20%, #5eead4);
+
+  --vp-shadow-1: 0 1px 2px rgba(0, 0, 0, 0.28);
+  --vp-shadow-2: 0 3px 12px rgba(0, 0, 0, 0.36);
+  --vp-shadow-3: 0 12px 32px rgba(0, 0, 0, 0.44);
+}
+
+/*
+ * Feature cards: stock VitePress leaves them flat and they read as dead
+ * weight under the hero. A hairline that picks up the brand on hover is
+ * enough to make them feel like the links they are.
+ */
+.VPFeature {
+  transition:
+    border-color 0.25s,
+    background-color 0.25s;
+}
+
+.VPFeature:hover {
+  border-color: var(--vp-c-brand-1);
+}
+
+.VPFeature .icon {
+  background-color: var(--vp-c-brand-soft);
+}
+
+/*
+ * This documentation is mostly configuration reference, so inline code appears
+ * constantly in prose -- every directive name is one. The stock treatment is
+ * loud at that density; drop the weight and let it sit inside the sentence.
+ */
+:not(pre) > code {
+  font-weight: 400;
+}
+
+/*
+ * Tables carry the directive references (configuration.md is 310 lines of
+ * them). Give the header some separation so a long table stays scannable.
+ */
+.vp-doc th {
+  font-size: 0.85em;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--vp-c-text-2);
+}
+
+/* Wide reference tables must scroll inside the page, never the page itself. */
+.vp-doc table {
+  display: block;
+  overflow-x: auto;
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,8 @@
+import DefaultTheme from 'vitepress/theme'
+import type { Theme } from 'vitepress'
+import './custom.css'
+
+// The stock theme, restyled through CSS variables only. No component
+// overrides: they are what make a docs site expensive to keep working across
+// VitePress upgrades, and nothing here needs one.
+export default DefaultTheme satisfies Theme

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,21 +18,27 @@ hero:
 
 features:
   - title: Rule engine
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>'
     details: Regular expressions compiled by Go's RE2, so matching is linear-time with no catastrophic backtracking. Rules carry a score; a request is blocked once the total reaches the anomaly threshold.
     link: /rules
   - title: Four inspection phases
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m12 2 9 5-9 5-9-5 9-5z"/><path d="m3 12 9 5 9-5"/><path d="m3 17 9 5 9-5"/></svg>'
     details: Request headers, request body, response headers and response body, each with its own rule set and target identifiers.
     link: /configuration
   - title: Blacklists and geo controls
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M3 12h18"/><path d="M12 3a15 15 0 0 1 0 18a15 15 0 0 1 0-18z"/></svg>'
     details: IP and CIDR ranges in a prefix trie, exact-match DNS lookups, MaxMind country and ASN filtering, and a periodically refreshed Tor exit-node list.
     link: /blacklists
   - title: Rate limiting
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20a8 8 0 1 1 8-8"/><path d="m12 12 5-3"/><path d="M12 4v2"/><path d="M4.9 7.5 6.3 8.6"/></svg>'
     details: Per-IP sliding window, optionally scoped to specific paths with regular expressions.
     link: /ratelimit
   - title: Observability
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M3 13h4l3 7 4-16 3 9h4"/></svg>'
     details: A JSON metrics endpoint, an async log worker with sensitive-data redaction, and worked examples for Prometheus, Grafana and ELK.
     link: /metrics
   - title: Hot reload
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-2.6-6.4"/><path d="M21 3v6h-6"/></svg>'
     details: File watchers on the rule files and both blacklists, with a documented matrix of what each reload covers and what still needs a caddy reload.
     link: /dynamicupdates
 ---


### PR DESCRIPTION
The stock VitePress theme is clean but anonymous — the site read as "documentation for some project" rather than for this one.

## Method

Rather than inventing a look, I checked what the major VitePress sites actually override, by pulling their built CSS:

| site | brand | signature |
|---|---|---|
| vitepress.dev | indigo | hero name gradient |
| vitest.dev | custom `--color-brand` | softened shadows, hero image off |
| hono.dev | orange | softened shadows |
| unocss.dev | blue | animated brand hue |

They all do the same small set of things — override `--vp-c-brand-1/2/3`, add **one** signature touch on the hero, soften shadows — and leave everything else stock. That restraint is the point.

Two of them (vitest, vueuse) pull fonts from Google Fonts. We deliberately don't, so the site stays free of third-party requests; bundled Inter is what vitepress.dev and hono.dev use anyway.

## Colour

Blue-cyan band: it reads as network infrastructure rather than alarm. Red stays reserved for the `danger` container, so it keeps its meaning.

Contrast was computed, not eyeballed. All values beat VitePress's own default of 4.48:1:

| | light | ratio | dark | ratio |
|---|---|---|---|---|
| `brand-1` links | `#075985` | 7.56:1 | `#38bdf8` | 8.01:1 |
| `brand-2` hover | `#0e7490` | 5.36:1 | `#7dd3fc` | 10.30:1 |
| `brand-3` buttons | `#0369a1` | 5.93:1 | `#0369a1` | 5.93:1 |

The hero gradient is kept dark enough to clear 3:1 as large text. The usual failure mode here is a pastel gradient that photographs well and cannot be read.

## Also

- **Six inline SVG feature icons** — inline rather than an icon font or a CDN, so the zero-third-party-request property holds.
- **Inline code loses its bold weight.** This documentation is mostly configuration reference, so directive names appear in nearly every sentence; at that density the stock treatment shouts.
- **Reference tables** get a quieter uppercase header and scroll inside their own box, so a wide table never scrolls the page.

CSS variables only, no component overrides — those are what make a docs site expensive to carry across VitePress upgrades.

## Gotcha found while building

A raw SVG feature icon must be passed as a **plain string**. Passing `icon: { svg: … }` routes through `VPImage`, which expects an image source, and **silently renders nothing** — no warning, no build error. Cost me a debug cycle; noted in the commit message.

## Verified on the build output

```
6 inline <svg> rendered on the home page
brand vars present for both themes, and after the indigo defaults in the cascade (offset 108414 vs 6950, so ours win)
hero gradient present for light and dark
external hosts in <script>/<link>: none
iconify references in index.html: 0
19 pages
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)