### PR TITLE
docs: fix two review findings from #122, and guard the class of bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ INFO  WAF middleware provisioned successfully
 - Caddy **v2.11.x** or newer (current build uses `github.com/caddyserver/caddy/v2 v2.11.2`)
 - [`xcaddy`](https://github.com/caddyserver/xcaddy) for building Caddy with plugins
 
-### Option 1 — Build with xcaddy (recommended)
+### Method 1 — Build with xcaddy (recommended)
 
 ```bash
 go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
@@ -94,14 +94,14 @@ xcaddy build --with github.com/fabriziosalmi/caddy-waf
 ./caddy list-modules | grep waf   # expect: http.handlers.waf
 ```
 
-### Option 2 — Quick script
+### Method 2 — Quick script
 
 ```bash
 curl -fsSL -H "Pragma: no-cache" \
   https://raw.githubusercontent.com/fabriziosalmi/caddy-waf/refs/heads/main/install.sh | bash
 ```
 
-### Option 3 — Build from source
+### Method 3 — Build from source
 
 ```bash
 git clone https://github.com/fabriziosalmi/caddy-waf.git
@@ -113,7 +113,7 @@ xcaddy build --with github.com/fabriziosalmi/caddy-waf=./
 ./caddy run
 ```
 
-### `caddy add-package`
+### Method 4 — `caddy add-package`
 
 The module is registered in Caddy's package registry, so an existing Caddy v2.7+ binary can pull it in without a Go toolchain:
 

--- a/docs/.vitepress/check-anchors.mjs
+++ b/docs/.vitepress/check-anchors.mjs
@@ -1,0 +1,82 @@
+/*
+ * Validate in-page anchors across docs/.
+ *
+ * VitePress fails the build on a link to a page that does not exist, but it
+ * does not check the #fragment. A link to a real page with a stale anchor
+ * therefore ships silently and lands the reader at the top of the page with no
+ * indication anything is wrong -- which is exactly how
+ * installation.md#option-1-... survived review and a green build, the headings
+ * there being "Method N" and not "Option N".
+ *
+ * Runs automatically before `npm run docs:build` via the npm pre-script hook,
+ * so it guards CI and local builds alike.
+ */
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, basename } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const DOCS = fileURLToPath(new URL('..', import.meta.url))
+
+/** GitHub/VitePress heading slug: strip markup, lowercase, spaces to hyphens,
+ *  drop everything else. An em dash vanishes, which is why "A — B" yields
+ *  "a--b" with a double hyphen. */
+function slug(heading) {
+  return [
+    ...heading
+      .replace(/`([^`]*)`/g, '$1')
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+      .trim()
+      .toLowerCase(),
+  ]
+    .map((ch) => (/[\p{L}\p{N}\-_]/u.test(ch) ? ch : /\s/.test(ch) ? '-' : ''))
+    .join('')
+}
+
+const files = readdirSync(DOCS).filter((f) => f.endsWith('.md'))
+
+const headings = new Map(
+  files.map((f) => [
+    f,
+    new Set(
+      readFileSync(join(DOCS, f), 'utf8')
+        .split('\n')
+        .flatMap((l) => {
+          const m = l.match(/^#{1,6}\s+(.*)$/)
+          return m ? [slug(m[1])] : []
+        }),
+    ),
+  ]),
+)
+
+const problems = []
+const linkRe = /\]\(([^)\s]*?)#([^)\s]+)\)/g
+
+for (const file of files) {
+  const lines = readFileSync(join(DOCS, file), 'utf8').split('\n')
+  lines.forEach((line, i) => {
+    for (const [, target, anchor] of line.matchAll(linkRe)) {
+      if (/^https?:/.test(target)) continue
+      const dest = target === '' ? file : basename(target)
+      // Only pages inside docs/ can be checked; links out to the repo cannot.
+      if (!headings.has(dest)) continue
+      if (!headings.get(dest).has(anchor)) {
+        problems.push({ file, line: i + 1, target: target || dest, anchor, dest })
+      }
+    }
+  })
+}
+
+if (problems.length) {
+  console.error(`\n${problems.length} broken anchor link(s):\n`)
+  for (const p of problems) {
+    const near = [...headings.get(p.dest)]
+      .filter((h) => h.split('-').pop() === p.anchor.split('-').pop())
+      .slice(0, 3)
+    console.error(`  ${p.file}:${p.line}  ->  ${p.target}#${p.anchor}`)
+    if (near.length) console.error(`      did you mean: ${near.join(', ')}`)
+  }
+  console.error('')
+  process.exit(1)
+}
+
+console.log(`anchors ok (${files.length} pages)`)

--- a/docs/add-package-guide.md
+++ b/docs/add-package-guide.md
@@ -43,8 +43,9 @@ caddy add-package github.com/fabriziosalmi/caddy-waf@v0.3.5
 Any tag from the [Releases](https://github.com/fabriziosalmi/caddy-waf/releases)
 page works. Without a version the build service uses the latest tag.
 
-Note that v0.3.4 and earlier carry a high-severity denial-of-service
-(GHSA-gfj3-cmff-q8wh); do not pin below v0.3.4.
+Note that v0.3.3 and earlier carry a high-severity denial-of-service
+([GHSA-gfj3-cmff-q8wh](https://github.com/fabriziosalmi/caddy-waf/security/advisories/GHSA-gfj3-cmff-q8wh)),
+fixed in v0.3.4; do not pin below v0.3.4.
 
 ## Remove
 
@@ -55,7 +56,7 @@ caddy remove-package github.com/fabriziosalmi/caddy-waf
 ## When to build with xcaddy instead
 
 `add-package` replaces a binary in place using a remote build service. Prefer
-[`xcaddy`](installation.md#option-1--build-with-xcaddy-recommended) when you
+[`xcaddy`](installation.md#method-1--build-with-xcaddy-recommended) when you
 need to build from a fork or an untagged commit, pin the Caddy version itself,
 build in an air-gapped environment, or produce reproducible artifacts in CI:
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "Documentation site for caddy-waf, built with VitePress.",
   "scripts": {
     "docs:dev": "vitepress dev docs",
+    "docs:check-anchors": "node docs/.vitepress/check-anchors.mjs",
+    "predocs:build": "npm run docs:check-anchors",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"
   },


### PR DESCRIPTION
Both findings from the automated review on #122 are correct. Fixed, plus a guard so the second class cannot recur silently.

## 1. Wrong security guidance in the install docs

`docs/add-package-guide.md` said:

> Note that **v0.3.4 and earlier** carry a high-severity denial-of-service (GHSA-gfj3-cmff-q8wh); do not pin below v0.3.4.

The advisory records:

```console
$ gh api repos/fabriziosalmi/caddy-waf/security-advisories/GHSA-gfj3-cmff-q8wh
affected: < 0.3.4   patched: 0.3.4
```

So **v0.3.4 is the fix**, not a vulnerable version — and the sentence contradicted its own follow-up clause. Corrected to "v0.3.3 and earlier", with the advisory linked.

Stating it plainly rather than filing it as a typo: this was **wrong security guidance in installation documentation**. A reader following it would have concluded the patched release was still vulnerable.

## 2. Broken anchor

The same page linked `installation.md#option-1--build-with-xcaddy-recommended`. That page numbers its sections **Method N**, so the anchor never resolved and the link silently dropped the reader at the top of the page.

### Root cause, fixed too

`README.md` numbered the same three install paths **Option N** while `docs/installation.md` numbered them **Method N** — two vocabularies for the same thing across the project's two most-read documents, which is what produced the mistake. README now uses **Method N**, and its `caddy add-package` section becomes **Method 4**, matching `installation.md` exactly. Verified nothing linked the old `#option-*` anchors.

## The guard

VitePress fails the build on a link to a page that does not exist, but it **does not validate the fragment**. A stale anchor therefore ships silently — this one survived both human review and a green CI run.

`docs/.vitepress/check-anchors.mjs` resolves every in-repo anchor link against the target page's actual headings, using GitHub's slug rules. It runs as the `predocs:build` npm script, so it gates local builds and CI without a separate workflow step.

Validated in both directions:

```console
$ npm run docs:build      # with the broken anchor restored
1 broken anchor link(s):
  add-package-guide.md:59  ->  installation.md#option-1--build-with-xcaddy-recommended
      did you mean: method-1--build-with-xcaddy-recommended
exit 1

$ npm run docs:build      # after the fix
anchors ok (18 pages)
build complete in 2.53s.
exit 0
```

A full audit of the tree found **no other broken anchors** — this was the only instance, not a systemic problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)