### PR TITLE
fix: the IP blacklist never blocked, and hot reload deadlocked the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.3.7] - 2026-07-28
+
+### Security
+Two defects in the blacklist subsystem, both silent. Reported in substance by [@doogienz](https://github.com/doogienz) in discussion [#96](https://github.com/fabriziosalmi/caddy-waf/discussions/96) on 2026-05-21, with the log evidence that pinned it down.
+
+- **The IP blacklist never blocked anything.** `loadIPBlacklist` took the trie by value, and both callers — `Provision` and `ReloadConfig` — dereferenced their pointer to satisfy that signature. Every `Insert` therefore landed in a copy discarded on return: the trie the middleware consults stayed empty, while the loader still logged `IP blacklist loaded {"valid_entries": N}`. Any deployment relying on `ip_blacklist_file`, including the 223,770-entry list bundled with the project, had no IP filtering at all and no indication of it. Present since **v0.0.7** (commit `c905277`, "switch to go-trie", 2025-10-10) — 15 releases.
+
+- **Hot-reloading a blacklist deadlocked the server.** `ReloadConfig` held `m.mu` and then called `loadRules`, which takes `m.mu` again; on Go's non-reentrant `RWMutex` the goroutine blocked forever *while still owning the write lock*. Since `isDNSBlacklisted` takes `m.mu.RLock()` on every request, all subsequent requests blocked forever — no crash, no log line. The file watcher calls `ReloadConfig` whenever `ip_blacklist_file` or `dns_blacklist_file` changes, and the documented Tor setup (`docs/dynamicupdates.md`) points `ip_blacklist_file` at the file the Tor fetcher rewrites every `update_interval` (default 24h), so the configuration the docs recommend wedges the server within a day of starting, unattended.
+
+Both are fixed: the trie is passed by pointer, and `ReloadConfig` builds the new structures outside the lock, swaps them under it, and never holds `m.mu` across a call that takes it again.
+
+### Added
+- `blacklist_enforcement_test.go` — four regression tests: the trie is actually populated (IPv4, IPv6, CIDR, with and without a port), the reload path repopulates it, `ReloadConfig` completes and releases the lock under a deadline, and a full `ServeHTTP` pass confirms a blacklisted client is refused, never reaches the upstream, and that `X-Forwarded-For` is honoured.
+
+### Changed
+- Bumped version constant `wafVersion` to `v0.3.7`.
+
 ## [v0.3.6] - 2026-07-28
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Web Application Firewall middleware for the [Caddy](https://caddyserver.com/) 
 
 - **Module ID**: `http.handlers.waf` — [registered in Caddy's package registry](https://caddyserver.com/docs/modules/http.handlers.waf), so `caddy add-package` and the [download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf) both work
 - **Go module path**: `github.com/fabriziosalmi/caddy-waf`
-- **Current version**: `v0.3.6` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
+- **Current version**: `v0.3.7` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
 - **License**: AGPL-3.0 — note this is a copyleft licence; check it suits your deployment before integrating
 
 ---
@@ -67,7 +67,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version  {"version":"v0.3.6"}
+INFO  WAF middleware version  {"version":"v0.3.7"}
 INFO  Rate limit configuration  {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded     {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}

--- a/blacklist_enforcement_test.go
+++ b/blacklist_enforcement_test.go
@@ -1,0 +1,183 @@
+package caddywaf
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/phemmer/go-iptrie"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// writeBlacklist writes entries to a temp file and returns its path.
+func writeBlacklist(t *testing.T, entries string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "ip_blacklist*.txt")
+	require.NoError(t, err)
+	_, err = f.WriteString(entries)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
+}
+
+// TestIPBlacklistIsActuallyPopulated guards against the trie being filled in a
+// copy rather than in the trie the middleware consults.
+//
+// loadIPBlacklist used to take the trie by value, and both callers dereferenced
+// their pointer to satisfy that signature. Every Insert therefore landed in a
+// copy discarded on return: the middleware's trie stayed empty, while the
+// loader still logged "IP blacklist loaded" with a non-zero entry count. The
+// blacklist enforced nothing, silently, and the logs said otherwise.
+func TestIPBlacklistIsActuallyPopulated(t *testing.T) {
+	logger := zap.NewNop()
+	path := writeBlacklist(t, "127.0.0.1\n203.0.113.7\n10.0.0.0/8\n2001:db8::1\n")
+
+	m := &Middleware{logger: logger, blacklistLoader: NewBlacklistLoader(logger)}
+	m.ipBlacklist = iptrie.NewTrie()
+	require.NoError(t, m.loadIPBlacklist(path, m.ipBlacklist))
+
+	for _, tc := range []struct {
+		addr    string
+		blocked bool
+	}{
+		{"127.0.0.1:53569", true},   // exact IPv4, with port as http.Request carries it
+		{"127.0.0.1", true},         // exact IPv4, bare
+		{"203.0.113.7:443", true},   // second exact entry
+		{"10.1.2.3:80", true},       // inside the /8
+		{"[2001:db8::1]:443", true}, // exact IPv6
+		{"8.8.8.8:443", false},      // not listed
+		{"11.0.0.1:80", false},      // just outside the /8
+	} {
+		assert.Equalf(t, tc.blocked, m.isIPBlacklisted(tc.addr),
+			"isIPBlacklisted(%q)", tc.addr)
+	}
+}
+
+// TestReloadConfigRepopulatesIPBlacklist covers the same defect on the hot-reload
+// path, which had its own dereferencing call site.
+func TestReloadConfigRepopulatesIPBlacklist(t *testing.T) {
+	logger := zap.NewNop()
+	path := writeBlacklist(t, "198.51.100.4\n")
+
+	m := &Middleware{
+		logger:          logger,
+		blacklistLoader: NewBlacklistLoader(logger),
+		IPBlacklistFile: path,
+		ipBlacklist:     iptrie.NewTrie(),
+	}
+	require.NoError(t, m.ReloadConfig())
+
+	assert.True(t, m.isIPBlacklisted("198.51.100.4:1234"),
+		"a reloaded blacklist must be consulted, not discarded")
+	assert.False(t, m.isIPBlacklisted("198.51.100.5:1234"))
+}
+
+// TestReloadConfigDoesNotDeadlock pins the hot-reload path against a
+// self-deadlock on Go's non-reentrant RWMutex.
+//
+// ReloadConfig used to take m.mu and then call loadRules, which takes m.mu
+// again. The goroutine blocked forever while still owning the write lock, so
+// every later request stalled on the RLock in isDNSBlacklisted. Since the file
+// watcher calls ReloadConfig whenever a blacklist file changes, editing one was
+// enough to wedge the server. The failure mode is a hang, so this asserts on a
+// deadline rather than on a return value.
+func TestReloadConfigDoesNotDeadlock(t *testing.T) {
+	logger := zap.NewNop()
+	m := &Middleware{
+		logger:          logger,
+		blacklistLoader: NewBlacklistLoader(logger),
+		IPBlacklistFile: writeBlacklist(t, "198.51.100.4\n"),
+		ipBlacklist:     iptrie.NewTrie(),
+		dnsBlacklist:    map[string]struct{}{},
+		ruleCache:       NewRuleCache(),
+		Rules:           map[int][]Rule{},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- m.ReloadConfig() }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("ReloadConfig deadlocked: it must not hold m.mu across loadRules")
+	}
+
+	// The write lock must have been released: a reader has to get through.
+	readerDone := make(chan bool, 1)
+	go func() { readerDone <- m.isDNSBlacklisted("example.com") }()
+	select {
+	case <-readerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a request-path reader blocked after ReloadConfig; the write lock was never released")
+	}
+}
+
+// TestBlacklistedIPIsBlockedEndToEnd drives a full request through ServeHTTP,
+// so the guarantee is "the client is refused", not merely "a lookup returns
+// true". Without this, a future refactor could keep the trie correct and still
+// fail to act on it.
+func TestBlacklistedIPIsBlockedEndToEnd(t *testing.T) {
+	logger := zap.NewNop()
+	path := writeBlacklist(t, "192.0.2.10\n")
+
+	m := &Middleware{
+		logger:                logger,
+		blacklistLoader:       NewBlacklistLoader(logger),
+		IPBlacklistFile:       path,
+		Rules:                 map[int][]Rule{},
+		AnomalyThreshold:      20,
+		ruleCache:             NewRuleCache(),
+		dnsBlacklist:          map[string]struct{}{},
+		ipBlacklist:           iptrie.NewTrie(),
+		requestValueExtractor: NewRequestValueExtractor(logger, false, 0),
+	}
+	require.NoError(t, m.loadIPBlacklist(path, m.ipBlacklist))
+
+	reached := false
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		reached = true
+		_, err := w.Write([]byte("UPSTREAM"))
+		return err
+	})
+
+	t.Run("blacklisted IP never reaches the upstream", func(t *testing.T) {
+		reached = false
+		req := httptest.NewRequest(http.MethodGet, testURL, nil)
+		req.RemoteAddr = "192.0.2.10:41234"
+		w := httptest.NewRecorder()
+		require.NoError(t, m.ServeHTTP(w, req, next))
+
+		assert.False(t, reached, "the upstream handler must not run")
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.NotContains(t, w.Body.String(), "UPSTREAM")
+	})
+
+	t.Run("an IP not on the list passes through", func(t *testing.T) {
+		reached = false
+		req := httptest.NewRequest(http.MethodGet, testURL, nil)
+		req.RemoteAddr = "192.0.2.11:41234"
+		w := httptest.NewRecorder()
+		require.NoError(t, m.ServeHTTP(w, req, next))
+
+		assert.True(t, reached)
+		assert.Equal(t, "UPSTREAM", w.Body.String())
+	})
+
+	t.Run("X-Forwarded-For is honoured for the blacklist", func(t *testing.T) {
+		reached = false
+		req := httptest.NewRequest(http.MethodGet, testURL, nil)
+		req.RemoteAddr = "203.0.113.99:41234"
+		req.Header.Set("X-Forwarded-For", "192.0.2.10, 70.41.3.18")
+		w := httptest.NewRecorder()
+		require.NoError(t, m.ServeHTTP(w, req, next))
+
+		assert.False(t, reached, "the upstream handler must not run")
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+}

--- a/caddywaf.go
+++ b/caddywaf.go
@@ -49,7 +49,7 @@ var (
 )
 
 // Add or update the version constant as needed
-const wafVersion = "v0.3.6" // update this value to the new release version when tagging
+const wafVersion = "v0.3.7" // update this value to the new release version when tagging
 
 // ==================== Initialization and Setup ====================
 
@@ -265,7 +265,7 @@ func (m *Middleware) Provision(ctx caddy.Context) error {
 	// Load IP blacklist
 	if m.IPBlacklistFile != "" {
 		m.ipBlacklist = iptrie.NewTrie()
-		err = m.loadIPBlacklist(m.IPBlacklistFile, *m.ipBlacklist)
+		err = m.loadIPBlacklist(m.IPBlacklistFile, m.ipBlacklist)
 		if err != nil {
 			return fmt.Errorf("failed to load IP blacklist: %w", err)
 		}
@@ -457,29 +457,41 @@ func (m *Middleware) ReloadRules() error {
 	return nil
 }
 
+// ReloadConfig rebuilds the blacklists and rule set from disk. It is called by
+// the file watcher when a blacklist file changes.
+//
+// The new structures are built off to the side and only swapped in under the
+// lock, and m.mu is never held across a call that takes it again. Holding it
+// across loadRules used to deadlock the goroutine on Go's non-reentrant
+// RWMutex while it still owned the write lock, so every later request blocked
+// forever on the RLock in isDNSBlacklisted -- one edit to a blacklist file was
+// enough to wedge the whole server.
 func (m *Middleware) ReloadConfig() error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	m.logger.Info("Reloading WAF configuration")
+
 	if m.IPBlacklistFile != "" {
 		newIPBlacklist := iptrie.NewTrie()
-		if err := m.loadIPBlacklist(m.IPBlacklistFile, *newIPBlacklist); err != nil {
+		if err := m.loadIPBlacklist(m.IPBlacklistFile, newIPBlacklist); err != nil {
 			m.logger.Error("Failed to reload IP blacklist", zap.String("file", m.IPBlacklistFile), zap.Error(err))
 			return fmt.Errorf("failed to reload IP blacklist: %v", err)
 		}
+		m.mu.Lock()
 		m.ipBlacklist = newIPBlacklist
+		m.mu.Unlock()
 	}
+
 	if m.DNSBlacklistFile != "" {
 		newDNSBlacklist := make(map[string]struct{})
 		if err := m.loadDNSBlacklist(m.DNSBlacklistFile, newDNSBlacklist); err != nil {
 			m.logger.Error("Failed to reload DNS blacklist", zap.String("file", m.DNSBlacklistFile), zap.Error(err))
 			return fmt.Errorf("failed to reload DNS blacklist: %v", err)
 		}
+		m.mu.Lock()
 		m.dnsBlacklist = newDNSBlacklist
+		m.mu.Unlock()
 	}
 
-	// Call the external loadRules function
+	// loadRules takes m.mu itself, so it must be called without holding it.
 	if err := m.loadRules(m.RuleFiles); err != nil {
 		m.logger.Error("Failed to reload rules", zap.Error(err))
 		return fmt.Errorf("failed to reload rules: %v", err)
@@ -489,7 +501,14 @@ func (m *Middleware) ReloadConfig() error {
 	return nil
 }
 
-func (m *Middleware) loadIPBlacklist(path string, blacklistMap iptrie.Trie) error {
+// loadIPBlacklist parses path and inserts every entry into blacklistTrie.
+//
+// The trie MUST be taken by pointer. It was previously accepted by value, and
+// both callers dereferenced their trie to satisfy that signature, so every
+// Insert landed in a copy that was discarded on return. The middleware's own
+// trie stayed empty while the loader still logged "IP blacklist loaded" with a
+// non-zero entry count -- so the blacklist silently enforced nothing.
+func (m *Middleware) loadIPBlacklist(path string, blacklistTrie *iptrie.Trie) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		m.logger.Warn("Skipping IP blacklist load, file does not exist", zap.String("file", path))
 		return nil
@@ -516,7 +535,7 @@ func (m *Middleware) loadIPBlacklist(path string, blacklistMap iptrie.Trie) erro
 			m.logger.Warn("Skipping invalid IP in blacklist", zap.String("ip", ip), zap.Error(err))
 			continue
 		}
-		blacklistMap.Insert(prefix, nil)
+		blacklistTrie.Insert(prefix, nil)
 	}
 	return nil
 }

--- a/docs/add-package-guide.md
+++ b/docs/add-package-guide.md
@@ -37,7 +37,7 @@ caddy list-modules | grep waf
 ## Pin a version
 
 ```bash
-caddy add-package github.com/fabriziosalmi/caddy-waf@v0.3.6
+caddy add-package github.com/fabriziosalmi/caddy-waf@v0.3.7
 ```
 
 Any tag from the [Releases](https://github.com/fabriziosalmi/caddy-waf/releases)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version          {"version":"v0.3.6"}
+INFO  WAF middleware version          {"version":"v0.3.7"}
 INFO  Rate limit configuration        {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded             {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}
@@ -69,7 +69,7 @@ The module is registered in Caddy's package registry, so an existing Caddy v2.7+
 caddy add-package github.com/fabriziosalmi/caddy-waf
 ```
 
-This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.3.6` if needed.
+This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.3.7` if needed.
 
 The module is also selectable on <https://caddyserver.com/download>.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,7 +41,7 @@ A representative response:
   "dns_blacklist_hits":            0,
   "rate_limiter_requests":         27004,
   "rate_limiter_blocked_requests": 23640,
-  "version":                       "v0.3.6"
+  "version":                       "v0.3.7"
 }
 ```
 


### PR DESCRIPTION
Two silent defects in the blacklist subsystem. Both found while investigating discussion [#96](https://github.com/fabriziosalmi/caddy-waf/discussions/96), open and unanswered since 2026-05-21.

## 1. The IP blacklist never blocked anything

`loadIPBlacklist` took the trie **by value**, and both callers — `Provision` (`caddywaf.go:268`) and `ReloadConfig` (`caddywaf.go:467`) — dereferenced their pointer to satisfy that signature:

```go
m.ipBlacklist = iptrie.NewTrie()
err = m.loadIPBlacklist(m.IPBlacklistFile, *m.ipBlacklist)   // ← a copy
```

Every `Insert` landed in that copy and was discarded on return. The trie the middleware consults stayed empty — while the loader kept logging `IP blacklist loaded {"valid_entries": N}`.

So any deployment relying on `ip_blacklist_file`, **including the 223,770-entry list bundled with this project**, had no IP filtering at all, and the logs actively said otherwise.

Present since **v0.0.7** (`c905277`, "switch to go-trie", 2025-10-10) — 15 releases.

**Verified three independent ways** before fixing:

1. Reproduced with a real Caddy binary: IP in the blacklist, request from that IP → `blocked: False`, backend reached. This happened with the layout from `caddyfile.example` too, ruling out the misconfiguration I first suspected.
2. Isolated in Go: via the `Provision` path `Contains(127.0.0.1)` → `false`; inserting into the middleware's own trie → `true`.
3. Read the signature and found the cause.

## 2. Hot-reloading a blacklist deadlocked the server

`ReloadConfig` held `m.mu` and then called `loadRules`, which takes `m.mu` again. On Go's non-reentrant `RWMutex` the goroutine blocks forever **while still owning the write lock**:

```
sync.(*RWMutex).Lock
  caddywaf.(*Middleware).loadRules       rules.go:163
  caddywaf.(*Middleware).ReloadConfig    caddywaf.go:483   ← already holds it
```

`isDNSBlacklisted` takes `m.mu.RLock()` on **every request**, so once that write lock is stuck, every subsequent request blocks forever. No crash, no log line — the server just stops answering.

**This is not an edge case.** The chain is entirely documented behaviour:

1. `docs/dynamicupdates.md:55` tells operators to point `ip_blacklist_file` at the Tor fetcher's file.
2. `tor.go:143` rewrites that file every `update_interval` — default **24h**.
3. `caddywaf.go:177` registers a watcher on `IPBlacklistFile`.

So the configuration the documentation recommends wedges the server within a day of starting, unattended, with no attacker involved.

## The fix

- The trie is passed by pointer; both call sites updated.
- `ReloadConfig` builds the new structures outside the lock, swaps them under it, and never holds `m.mu` across a call that takes it again. Strictly better than before: the expensive parsing no longer runs under the write lock either.

## Regression tests

New `blacklist_enforcement_test.go`:

| Test | Guards |
|---|---|
| `TestIPBlacklistIsActuallyPopulated` | trie really filled — IPv4, IPv6, CIDR, with and without a port |
| `TestReloadConfigRepopulatesIPBlacklist` | the reload call site, which had the same defect |
| `TestReloadConfigDoesNotDeadlock` | completes under a deadline **and** releases the lock, verified by a reader getting through |
| `TestBlacklistedIPIsBlockedEndToEnd` | full `ServeHTTP`: client refused, upstream never runs, `X-Forwarded-For` honoured |

The deadlock test asserts on a deadline because the failure mode is a hang, not a wrong value — before the fix `TestReloadConfigRepopulatesIPBlacklist` ran for 120s and timed out.

Full suite green.

## Credit

Reported in substance by **@doogienz** in #96 on 2026-05-21, with the log evidence that pinned it down. It sat unanswered for two months.

🤖 Generated with [Claude Code](https://claude.com/claude-code)