### PR TITLE
fix: a forged X-Forwarded-For bypassed the IP blacklist entirely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.3.8] - 2026-07-28
+
+### Security
+**A single request header bypassed the IP blacklist entirely.** Phase 1 consulted `X-Forwarded-For` *instead of* `r.RemoteAddr` whenever the header was present:
+
+```go
+if xForwardedFor != "" {
+    if m.isIPBlacklisted(firstIP) { block }
+    // no else -- r.RemoteAddr was never checked
+} else {
+    if m.isIPBlacklisted(r.RemoteAddr) { block }
+}
+```
+
+Any blacklisted client could send `X-Forwarded-For: 8.8.8.8` and skip the check. No tooling, no preconditions, no authentication — one arbitrary header. Demonstrated end to end: the same client is refused with `403` without the header and served `200` with it.
+
+The peer address is now checked **first and unconditionally**, since it is the only value a client cannot forge, and the forwarded chain is checked **in addition** rather than instead. Checking more addresses can only block more, never less. A client can therefore blacklist itself by forging a listed address, which is harmless. Deciding which forwarded values to *trust* requires a `trusted_proxies` option and is tracked in [#94](https://github.com/fabriziosalmi/caddy-waf/issues/94).
+
+This was masked until v0.3.7: before that the blacklist was never populated at all (see v0.3.7), so nothing was bypassable because nothing was enforced. Fixing enforcement made this the live bypass, which is why it ships one release later.
+
+Covered by `GHSA-w6gv-76q4-prqg`, updated to reflect **v0.3.8** as the patched version.
+
+### Added
+- `TestBlacklistedIPIsBlockedEndToEnd/a_forged_X-Forwarded-For_cannot_skip_the_check` — a blacklisted peer sending a clean `X-Forwarded-For` must still be refused.
+
+### Changed
+- Bumped version constant `wafVersion` to `v0.3.8`.
+
 ## [v0.3.7] - 2026-07-28
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Web Application Firewall middleware for the [Caddy](https://caddyserver.com/) 
 
 - **Module ID**: `http.handlers.waf` — [registered in Caddy's package registry](https://caddyserver.com/docs/modules/http.handlers.waf), so `caddy add-package` and the [download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf) both work
 - **Go module path**: `github.com/fabriziosalmi/caddy-waf`
-- **Current version**: `v0.3.7` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
+- **Current version**: `v0.3.8` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
 - **License**: AGPL-3.0 — note this is a copyleft licence; check it suits your deployment before integrating
 
 ---
@@ -67,7 +67,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version  {"version":"v0.3.7"}
+INFO  WAF middleware version  {"version":"v0.3.8"}
 INFO  Rate limit configuration  {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded     {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}

--- a/blacklist_enforcement_test.go
+++ b/blacklist_enforcement_test.go
@@ -169,6 +169,21 @@ func TestBlacklistedIPIsBlockedEndToEnd(t *testing.T) {
 		assert.Equal(t, "UPSTREAM", w.Body.String())
 	})
 
+	t.Run("a forged X-Forwarded-For cannot skip the check", func(t *testing.T) {
+		// The peer address is blacklisted; the client forges a clean XFF.
+		// Consulting XFF *instead of* the peer address used to let this
+		// through, making the whole blacklist bypassable with one header.
+		reached = false
+		req := httptest.NewRequest(http.MethodGet, testURL, nil)
+		req.RemoteAddr = "192.0.2.10:41234"
+		req.Header.Set("X-Forwarded-For", "8.8.8.8")
+		w := httptest.NewRecorder()
+		require.NoError(t, m.ServeHTTP(w, req, next))
+
+		assert.False(t, reached, "a forged X-Forwarded-For must not bypass the blacklist")
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
 	t.Run("X-Forwarded-For is honoured for the blacklist", func(t *testing.T) {
 		reached = false
 		req := httptest.NewRequest(http.MethodGet, testURL, nil)

--- a/caddywaf.go
+++ b/caddywaf.go
@@ -49,7 +49,7 @@ var (
 )
 
 // Add or update the version constant as needed
-const wafVersion = "v0.3.7" // update this value to the new release version when tagging
+const wafVersion = "v0.3.8" // update this value to the new release version when tagging
 
 // ==================== Initialization and Setup ====================
 

--- a/docs/add-package-guide.md
+++ b/docs/add-package-guide.md
@@ -37,7 +37,7 @@ caddy list-modules | grep waf
 ## Pin a version
 
 ```bash
-caddy add-package github.com/fabriziosalmi/caddy-waf@v0.3.7
+caddy add-package github.com/fabriziosalmi/caddy-waf@v0.3.8
 ```
 
 Any tag from the [Releases](https://github.com/fabriziosalmi/caddy-waf/releases)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version          {"version":"v0.3.7"}
+INFO  WAF middleware version          {"version":"v0.3.8"}
 INFO  Rate limit configuration        {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded             {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}
@@ -69,7 +69,7 @@ The module is registered in Caddy's package registry, so an existing Caddy v2.7+
 caddy add-package github.com/fabriziosalmi/caddy-waf
 ```
 
-This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.3.7` if needed.
+This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.3.8` if needed.
 
 The module is also selectable on <https://caddyserver.com/download>.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,7 +41,7 @@ A representative response:
   "dns_blacklist_hits":            0,
   "rate_limiter_requests":         27004,
   "rate_limiter_blocked_requests": 23640,
-  "version":                       "v0.3.7"
+  "version":                       "v0.3.8"
 }
 ```
 

--- a/handler.go
+++ b/handler.go
@@ -288,29 +288,34 @@ func (m *Middleware) handlePhase(w http.ResponseWriter, r *http.Request, phase i
 	if phase == 1 {
 		// IP blacklisting - the highest priority
 		m.logger.Debug("Checking for IP blacklisting", zap.String("remote_addr", r.RemoteAddr)) // Added log for checking before to isIPBlacklisted call
-		xForwardedFor := r.Header.Get("X-Forwarded-For")
-		if xForwardedFor != "" {
-			ips := strings.Split(xForwardedFor, ",")
-			if len(ips) > 0 {
-				firstIP := strings.TrimSpace(ips[0])
-				m.logger.Debug("Checking IP blacklist with X-Forwarded-For", zap.String("remote_addr_xff", firstIP), zap.String("r.RemoteAddr", r.RemoteAddr))
-				if m.isIPBlacklisted(firstIP) {
-					m.logger.Debug("Starting IP blacklist phase")
-					m.blockRequest(w, r, state, http.StatusForbidden, "ip_blacklist", "ip_blacklist_rule",
-						zap.String("message", "Request blocked by IP blacklist"),
-					)
-					if m.CustomResponses != nil {
-						m.writeCustomResponse(w, state.StatusCode)
-					}
-					return
+		// Check the peer address FIRST and unconditionally.
+		//
+		// This used to consult X-Forwarded-For *instead of* r.RemoteAddr
+		// whenever the header was present, so a blacklisted client could send
+		// any X-Forwarded-For value and skip the check entirely -- a one-header
+		// bypass of the whole blacklist. The peer address is the only value a
+		// client cannot forge, so it is always checked.
+		//
+		// The forwarded chain is checked as well, which can only ever block
+		// more, never less. Note that a client can therefore blacklist itself
+		// by forging a listed address; that is harmless. Deciding which
+		// forwarded values to *trust* needs a trusted_proxies option and is
+		// tracked in issue #94.
+		candidates := []string{r.RemoteAddr}
+		if xForwardedFor := r.Header.Get("X-Forwarded-For"); xForwardedFor != "" {
+			for _, hop := range strings.Split(xForwardedFor, ",") {
+				if hop = strings.TrimSpace(hop); hop != "" {
+					candidates = append(candidates, hop)
 				}
-			} else {
-				m.logger.Debug("X-Forwarded-For header present but empty or invalid")
 			}
-		} else {
-			m.logger.Debug("X-Forwarded-For header not present using r.RemoteAddr")
-			if m.isIPBlacklisted(r.RemoteAddr) {
-				m.logger.Debug("Starting IP blacklist phase")
+		}
+
+		for _, candidate := range candidates {
+			if m.isIPBlacklisted(candidate) {
+				m.logger.Debug("Starting IP blacklist phase",
+					zap.String("matched", candidate),
+					zap.String("remote_addr", r.RemoteAddr),
+				)
 				m.blockRequest(w, r, state, http.StatusForbidden, "ip_blacklist", "ip_blacklist_rule",
 					zap.String("message", "Request blocked by IP blacklist"),
 				)


### PR DESCRIPTION
Found while verifying the answer to discussion #55. The IP blacklist could be skipped with one arbitrary request header.

## The defect

Phase 1 consulted `X-Forwarded-For` **instead of** `r.RemoteAddr` whenever the header was present:

```go
if xForwardedFor != "" {
    if m.isIPBlacklisted(firstIP) { block }
    // no else -- r.RemoteAddr was never checked
} else {
    if m.isIPBlacklisted(r.RemoteAddr) { block }
}
```

A blacklisted client sends `X-Forwarded-For: 8.8.8.8` and the check never looks at who they actually are.

Demonstrated end to end against `ServeHTTP`, same client, same blacklist:

```
blacklisted, no XFF              -> status 403, upstream reached=false
blacklisted, XFF: 8.8.8.8        -> status 200, upstream reached=true
```

No tooling, no preconditions, no authentication.

## Why it surfaces now

It was masked until v0.3.7. Before that the blacklist was never populated at all (`loadIPBlacklist` filled a copy of the trie — see #130), so nothing was bypassable because nothing was enforced. Fixing enforcement made this the live bypass, which is why it ships one release later rather than together.

## The fix

- `r.RemoteAddr` is checked **first and unconditionally**. It is the only value a client cannot forge.
- The forwarded chain is checked **in addition**, not instead — so deployments behind a real proxy keep working.

Checking more addresses can only ever block more, never less. A client can blacklist *itself* by forging a listed address; that is harmless.

Deciding which forwarded values to **trust** is a different problem — it needs a `trusted_proxies` option, and it is tracked in #94. This PR closes the bypass without pretending to solve that.

## Regression test

`TestBlacklistedIPIsBlockedEndToEnd/a_forged_X-Forwarded-For_cannot_skip_the_check`: a blacklisted peer sending a clean `X-Forwarded-For` must still be refused. The sibling subtest confirms a genuine proxied client is still matched via `X-Forwarded-For`, so the fix does not regress the behind-proxy case.

Full suite green, `go vet` clean.

## Advisory

`GHSA-w6gv-76q4-prqg` will be updated to name **v0.3.8** as the patched version. Leaving it at v0.3.7 would point users at a release whose blacklist is bypassable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)