### PR TITLE
fix: ReloadRules deadlock, DNS blacklist bypass, IP blacklist data race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.3.9] - 2026-07-28
+
+### Security
+Two further defects in the same subsystem, one of them the sibling of a bug fixed in v0.3.7. Both were surfaced by an adversarial sweep that drives real requests through `ServeHTTP` and asks whether the client is actually refused, rather than whether a helper returns `true`.
+
+- **`ReloadRules` had the identical self-deadlock fixed in `ReloadConfig`.** It took `m.mu` and then called `loadRules`, which takes `m.mu` again; the goroutine blocked forever while owning the write lock, so every later request stalled on the `RLock` in the request path. This is the *primary* hot-reload branch: `startFileWatcher` routes any changed path containing `"rule"` to `ReloadRules`, which means editing `rules.json` — the case `docs/dynamicupdates.md` documents — wedged the server. v0.3.7 fixed one branch of the watcher and missed the other. Found by the automated review on [#130](https://github.com/fabriziosalmi/caddy-waf/pull/130).
+
+- **The DNS blacklist was bypassable, and inert on non-default ports.** `isDNSBlacklisted` only lowercased and trimmed the `Host` header, so `evil.example:8080` and `evil.example.` both missed an entry for `evil.example`. `r.Host` carries the port whenever the site is served on anything other than 80/443 — which every example in this repository does — so those deployments had no DNS filtering at all; and a client may send an explicit `:443` even on the default port, making it a one-header bypass. Hosts are now normalised (lowercase, port stripped, trailing dot removed, IPv6 brackets removed).
+
+### Fixed
+- **Data race on the IP blacklist during hot reload.** `ReloadConfig` swapped `m.ipBlacklist` under `m.mu`, but `isIPBlacklisted` read it without taking the lock, so the swap never synchronised with in-flight requests. The read is now under `RLock`, mirroring `isDNSBlacklisted`. Found by the automated review on [#130](https://github.com/fabriziosalmi/caddy-waf/pull/130).
+- Documentation described the pre-v0.3.8 `X-Forwarded-For` behaviour ("first XFF value if present, otherwise `r.RemoteAddr`"), which stopped being true when that bypass was closed.
+
+### Added
+- `TestReloadRulesDoesNotDeadlock` — the branch v0.3.7 missed, asserted on a deadline and followed by a reader that must get through.
+- The full suite now passes under `-race`.
+
+### Changed
+- Documented Go requirement corrected to **1.25.1**. `go.mod` declares it because `caddy/v2 v2.11.4` and `go.step.sm/crypto` require it and Go propagates the maximum; forcing `1.25.0` breaks the build.
+- Bumped version constant `wafVersion` to `v0.3.9`.
+
 ## [v0.3.8] - 2026-07-28
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Web Application Firewall middleware for the [Caddy](https://caddyserver.com/) 
 
 - **Module ID**: `http.handlers.waf` — [registered in Caddy's package registry](https://caddyserver.com/docs/modules/http.handlers.waf), so `caddy add-package` and the [download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf) both work
 - **Go module path**: `github.com/fabriziosalmi/caddy-waf`
-- **Current version**: `v0.3.8` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
+- **Current version**: `v0.3.9` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
 - **License**: AGPL-3.0 — note this is a copyleft licence; check it suits your deployment before integrating
 
 ---
@@ -67,7 +67,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version  {"version":"v0.3.8"}
+INFO  WAF middleware version  {"version":"v0.3.9"}
 INFO  Rate limit configuration  {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded     {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}
@@ -82,7 +82,7 @@ INFO  WAF middleware provisioned successfully
 
 ### Requirements
 
-- Go **1.25** or newer ([`go.mod`](go.mod) declares `go 1.25`)
+- Go **1.25.1** or newer ([`go.mod`](go.mod) declares `go 1.25.1`, propagated from `caddy/v2` which requires it)
 - Caddy **v2.11.x** or newer (current build uses `github.com/caddyserver/caddy/v2 v2.11.4`)
 - [`xcaddy`](https://github.com/caddyserver/xcaddy) for building Caddy with plugins
 

--- a/blacklist.go
+++ b/blacklist.go
@@ -78,7 +78,18 @@ func (m *Middleware) isIPBlacklisted(addr string) bool {
 		return false
 	}
 
-	if m.ipBlacklist.Contains(parsedIP) {
+	// ReloadConfig swaps m.ipBlacklist under m.mu, so the read must be
+	// synchronised or the swap races with every in-flight request. Mirrors
+	// what isDNSBlacklisted already does for the DNS map.
+	m.mu.RLock()
+	trie := m.ipBlacklist
+	m.mu.RUnlock()
+
+	if trie == nil {
+		return false
+	}
+
+	if trie.Contains(parsedIP) {
 		m.muIPBlacklistMetrics.Lock()                            // Acquire lock before accessing shared counter
 		m.IPBlacklistBlockCount++                                // Increment the counter
 		m.muIPBlacklistMetrics.Unlock()                          // Release lock after accessing counter
@@ -98,8 +109,37 @@ func (m *Middleware) isCountryInList(remoteAddr string, countryList []string, ge
 }
 
 // isDNSBlacklisted checks if the given host is in the DNS blacklist.
+// normalizeHost reduces a Host header to the bare hostname used for blacklist
+// lookups: lowercased, without the optional port, and without the trailing dot
+// of a fully qualified name.
+//
+// Both of those are client-controlled and were previously left in place, so
+// "evil.example:8080" and "evil.example." both missed an entry for
+// "evil.example". The port form is not exotic: r.Host carries the port
+// whenever the site is served on anything other than 80/443 -- which every
+// example in this repository does -- and a client may send an explicit
+// ":443" even there. The blacklist was bypassable with one header, and inert
+// altogether on a non-default port.
+func normalizeHost(host string) string {
+	h := strings.ToLower(strings.TrimSpace(host))
+	if h == "" {
+		return ""
+	}
+	// Strip the port. net.SplitHostPort fails when there is none, and would
+	// also mis-handle a bare IPv6 literal, so only take its result on success.
+	if stripped, _, err := net.SplitHostPort(h); err == nil && stripped != "" {
+		h = stripped
+	}
+	// "example.com." and "example.com" are the same name.
+	h = strings.TrimSuffix(h, ".")
+	// A bracketed IPv6 literal reaches us as "[::1]".
+	h = strings.TrimPrefix(h, "[")
+	h = strings.TrimSuffix(h, "]")
+	return h
+}
+
 func (m *Middleware) isDNSBlacklisted(host string) bool {
-	normalizedHost := strings.ToLower(strings.TrimSpace(host))
+	normalizedHost := normalizeHost(host)
 	if normalizedHost == "" {
 		m.logger.Warn("Empty host provided for DNS blacklist check")
 		return false

--- a/blacklist_enforcement_test.go
+++ b/blacklist_enforcement_test.go
@@ -118,6 +118,45 @@ func TestReloadConfigDoesNotDeadlock(t *testing.T) {
 	}
 }
 
+// TestReloadRulesDoesNotDeadlock covers the sibling of the ReloadConfig
+// defect. The file watcher routes any changed path containing "rule" to
+// ReloadRules, so this is the primary hot-reload case -- editing rules.json.
+func TestReloadRulesDoesNotDeadlock(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "rules*.json")
+	require.NoError(t, err)
+	_, err = f.WriteString(`[{"id":"r1","pattern":"x","targets":["URI"],"phase":1,"score":1,"action":"log"}]`)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	logger := zap.NewNop()
+	m := &Middleware{
+		logger:          logger,
+		blacklistLoader: NewBlacklistLoader(logger),
+		RuleFiles:       []string{f.Name()},
+		Rules:           map[int][]Rule{},
+		ruleCache:       NewRuleCache(),
+		ipBlacklist:     iptrie.NewTrie(),
+		dnsBlacklist:    map[string]struct{}{},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- m.ReloadRules() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("ReloadRules deadlocked: it must not hold m.mu across loadRules")
+	}
+
+	readerDone := make(chan bool, 1)
+	go func() { readerDone <- m.isIPBlacklisted("192.0.2.1:1") }()
+	select {
+	case <-readerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a request-path reader blocked after ReloadRules")
+	}
+}
+
 // TestBlacklistedIPIsBlockedEndToEnd drives a full request through ServeHTTP,
 // so the guarantee is "the client is refused", not merely "a lookup returns
 // true". Without this, a future refactor could keep the trie correct and still

--- a/caddywaf.go
+++ b/caddywaf.go
@@ -49,7 +49,7 @@ var (
 )
 
 // Add or update the version constant as needed
-const wafVersion = "v0.3.8" // update this value to the new release version when tagging
+const wafVersion = "v0.3.9" // update this value to the new release version when tagging
 
 // ==================== Initialization and Setup ====================
 
@@ -442,10 +442,15 @@ func (m *Middleware) startFileWatcher(filePaths []string) {
 	}
 }
 
+// ReloadRules re-reads the rule files. It is called by the file watcher when a
+// path containing "rule" changes, which is the primary hot-reload case.
+//
+// It must NOT take m.mu: loadRules takes it, and Go's RWMutex is not
+// reentrant, so an outer lock self-deadlocked the goroutine while it still
+// owned the write lock -- wedging every later request on the RLock in the
+// request path. Same defect as the one fixed in ReloadConfig; this branch was
+// missed there and is covered by TestReloadRulesDoesNotDeadlock.
 func (m *Middleware) ReloadRules() error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	m.logger.Info("Reloading WAF rules")
 	// Call the external loadRules function
 	if err := m.loadRules(m.RuleFiles); err != nil {

--- a/docs/add-package-guide.md
+++ b/docs/add-package-guide.md
@@ -37,7 +37,7 @@ caddy list-modules | grep waf
 ## Pin a version
 
 ```bash
-caddy add-package github.com/fabriziosalmi/caddy-waf@v0.3.8
+caddy add-package github.com/fabriziosalmi/caddy-waf@v0.3.9
 ```
 
 Any tag from the [Releases](https://github.com/fabriziosalmi/caddy-waf/releases)

--- a/docs/blacklists.md
+++ b/docs/blacklists.md
@@ -15,7 +15,8 @@ The middleware loads two blacklists at startup and on demand: an IP blacklist an
 - **Configuration directive**: `ip_blacklist_file <path>`
 - **Storage**: a [`go-iptrie`](https://github.com/phemmer/go-iptrie) prefix trie. Single addresses are stored as `/32` (IPv4) or `/128` (IPv6) prefixes; CIDR ranges are stored as-is.
 - **Lookup path**: at request time the source IP is parsed with `netip.ParseAddr` and a `Contains` check against the trie is performed. If the file is missing, the lookup is a no-op (no requests are blocked by the IP layer).
-- **Source IP selection**: when the `X-Forwarded-For` header is present, the **first** comma-separated value is used; otherwise `r.RemoteAddr` (host portion) is used.
+- **Source IP selection**: `r.RemoteAddr` (host portion) is **always** checked, since it is the only value a client cannot forge. Every hop in `X-Forwarded-For` is checked **in addition**, so a deployment behind a proxy still matches on the forwarded client IP. Consulting the header *instead of* the peer address, as releases before v0.3.8 did, let any blacklisted client bypass the list with one header (GHSA-gfj3-cmff-q8wh's sibling advisory, GHSA-w6gv-76q4-prqg).
+- **Host normalisation**: the DNS blacklist lowercases the `Host` header and strips the port and any trailing dot before matching, so `evil.example`, `EVIL.EXAMPLE:8080` and `evil.example.` all match the same entry.
 - **Validation**: each entry is parsed first as a CIDR range (`net.ParseCIDR`) and, on failure, as a single IP (`net.ParseIP`). Invalid lines are logged at WARN level and counted as `invalid_entries`; valid lines are counted as `valid_entries`.
 
 ### Accepted entry forms

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@ For each incoming request, [`Middleware.ServeHTTP`](https://github.com/fabrizios
 
 The order below reflects the actual code in [`handler.go`](https://github.com/fabriziosalmi/caddy-waf/blob/main/handler.go) (`handlePhase`, `phase==1`):
 
-1. **IP blacklist** — uses `X-Forwarded-For` first IP if present, otherwise `r.RemoteAddr`. Match → `403`.
+1. **IP blacklist** — always checks `r.RemoteAddr`, plus every `X-Forwarded-For` hop in addition. Match → `403`.
 2. **DNS blacklist** — exact (case-insensitive) match against `r.Host`. Match → `403`.
 3. **Rate limit** — when configured. Exceeded → `429 Too Many Requests`.
 4. **Country whitelist** — when enabled, request is blocked unless the source country is in the list. On lookup failure: `geoip_fail_open` controls behaviour.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@
 
 | Component | Minimum version | Source of truth |
 |---|---|---|
-| Go | **1.25** | [`go.mod`](https://github.com/fabriziosalmi/caddy-waf/blob/main/go.mod) — `go 1.25` |
+| Go | **1.25.1** | [`go.mod`](https://github.com/fabriziosalmi/caddy-waf/blob/main/go.mod) — `go 1.25.1`, propagated from `caddy/v2` |
 | Caddy | **v2.11.x** | [`go.mod`](https://github.com/fabriziosalmi/caddy-waf/blob/main/go.mod) — `github.com/caddyserver/caddy/v2 v2.11.4` |
 | `xcaddy` | latest | [github.com/caddyserver/xcaddy](https://github.com/caddyserver/xcaddy) |
 | MaxMind GeoLite2 Country MMDB | optional, only when using country block / whitelist | [maxmind.com](https://www.maxmind.com/) |
@@ -36,7 +36,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version          {"version":"v0.3.8"}
+INFO  WAF middleware version          {"version":"v0.3.9"}
 INFO  Rate limit configuration        {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded             {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}
@@ -69,7 +69,7 @@ The module is registered in Caddy's package registry, so an existing Caddy v2.7+
 caddy add-package github.com/fabriziosalmi/caddy-waf
 ```
 
-This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.3.8` if needed.
+This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.3.9` if needed.
 
 The module is also selectable on <https://caddyserver.com/download>.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,7 +41,7 @@ A representative response:
   "dns_blacklist_hits":            0,
   "rate_limiter_requests":         27004,
   "rate_limiter_blocked_requests": 23640,
-  "version":                       "v0.3.8"
+  "version":                       "v0.3.9"
 }
 ```
 


### PR DESCRIPTION
Three more defects in the blacklist/reload subsystem. **Two were found by the automated review on #130** — I fixed one branch of the watcher and missed the other. The third came from an adversarial sweep.

## 1. `ReloadRules` had the identical deadlock fixed in `ReloadConfig`

```go
func (m *Middleware) ReloadRules() error {
    m.mu.Lock()
    defer m.mu.Unlock()
    ...
    if err := m.loadRules(m.RuleFiles); err != nil {   // loadRules takes m.mu again
```

Verified empirically — it does not return within 5 seconds.

**This is the primary hot-reload branch.** `startFileWatcher` routes any changed path containing `"rule"` to `ReloadRules`, so editing `rules.json` — the case `docs/dynamicupdates.md` documents — wedged the server. v0.3.7 fixed `ReloadConfig` and left this one, so v0.3.7 *and* v0.3.8 still deadlocked on the most common reload.

## 2. DNS blacklist: bypassable, and inert on non-default ports

`isDNSBlacklisted` only lowercased and trimmed the `Host` header:

| `Host` | before | after |
|---|---|---|
| `evil.example` | 403 | 403 |
| `EVIL.EXAMPLE` | 403 | 403 |
| `evil.example:8080` | **200 — bypassed** | 403 |
| `evil.example.` | **200 — bypassed** | 403 |
| `good.example` | 200 | 200 |

`r.Host` carries the port whenever the site is served on anything other than 80/443 — **which every example in this repository does** (`:8080`). Those deployments had no DNS filtering at all. And a client may send an explicit `Host: evil.example:443` even on the default port, which makes it a one-header bypass on top.

Hosts are now normalised: lowercase, port stripped, trailing dot removed, IPv6 brackets removed.

## 3. Data race on the IP blacklist during hot reload

`ReloadConfig` swapped `m.ipBlacklist` under `m.mu`, but `isIPBlacklisted` read it without taking the lock — so the lock synchronised with nobody. Now read under `RLock`, mirroring `isDNSBlacklisted`.

The suite now runs green under `-race`.

## Also

- Documentation still described the **pre-v0.3.8** `X-Forwarded-For` behaviour ("first XFF value if present, otherwise `r.RemoteAddr`"). Corrected in `docs/blacklists.md` and `docs/configuration.md`.
- Stated Go requirement corrected to **1.25.1**. The review suggested reverting `go.mod` to `1.25.0`; that is not applicable — `caddy/v2 v2.11.4` and `go.step.sm/crypto` both declare `go 1.25.1` and Go propagates the maximum. Forcing `1.25.0` fails with `updates to go.mod needed`. The docs were the thing out of step.

## Audit

Before tagging I enumerated every function that takes `m.mu` and what it calls, rather than fixing what I happened to notice:

```
ReloadConfig      [Lock]   -> loadRules   (scoped: lock released before the call, proven by test)
isDNSBlacklisted  [RLock]
isIPBlacklisted   [RLock]
loadRules         [Lock]
```

`ReloadRules` no longer appears. No nested acquisition remains.

## Tests

`TestReloadRulesDoesNotDeadlock` — asserts on a deadline, then a reader must get through, confirming the write lock was released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)