### PR TITLE
feat: publish container images to ghcr, and make docker build use the source

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,32 @@
+# The build context is now the source tree (see Dockerfile), so keep out
+# everything the build does not need. node_modules alone is larger than the
+# rest of the repository combined.
+
+# Pre-existing entries, kept: xcaddy leaves buildenv_* behind, and `go` was a
+# stray local toolchain directory.
 buildenv_*
 go
+
+.git
+.github
+node_modules
+docs
+# NOTE: ui/ is deliberately NOT excluded. assets.go embeds it behind the
+# with_ui build tag, and dropping it from the context would break that build
+# in a way that is invisible until someone tries it.
+*.md
+!README.md
+.dockerignore
+Dockerfile
+docker-compose.yml
+package.json
+package-lock.json
+*_test.go
+benchmark.py
+caddytest.py
+test.py
+e2e.py
+debug_waf.py
+check_waf_config.py
+get_*.py
+debug_test_results.py

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,98 @@
+name: Docker
+
+on:
+  push:
+    tags: ['v*']
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'docker-compose.yml'
+      - '.github/workflows/docker.yml'
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  # Builds on pull requests without pushing, so a broken Dockerfile fails in
+  # review. Nothing built this image before, which is how it came to `git clone`
+  # the repository instead of using the build context, and to pin a Go version
+  # older than go.mod requires.
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: ${{ env.IMAGE }}:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # An image that builds but does not run is not much use. Confirm the WAF
+      # is actually compiled in rather than trusting a green build.
+      - name: Verify the module is present
+        run: |
+          docker run --rm --entrypoint caddy ${{ env.IMAGE }}:ci version
+          docker run --rm --entrypoint caddy ${{ env.IMAGE }}:ci list-modules \
+            | grep -qx 'http.handlers.waf'
+          echo "http.handlers.waf present"
+
+  publish:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Version tags as well as `latest`, so a deployment can pin. `latest`
+      # alone would leave anyone who pulled before a security release silently
+      # on the old image with no way to name the one they wanted.
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.3.10] - 2026-07-28
+
+### Fixed
+- **`docker build .` ignored your source tree.** The Dockerfile ran `git clone https://github.com/fabriziosalmi/caddy-waf.git` and built that, so the build context was never used: the image contained whatever happened to be on `main` at build time, could not be pinned to a version, and a CI image build would have tested the wrong code. The build context is now the source.
+- **The builder image was older than `go.mod` requires.** `golang:1.24-alpine` against a module declaring `go 1.25.1`; it only worked because `GOTOOLCHAIN=auto` silently downloaded a newer toolchain mid-build. Now `golang:1.26-alpine`.
+
+### Added
+- **Published container images at `ghcr.io/fabriziosalmi/caddy-waf`**, built on release tags for `linux/amd64` and `linux/arm64`. Tagged by version as well as `latest`, so a deployment can pin — `latest` alone would leave anyone who pulled before a security release with no way to name the image they wanted.
+- **`.github/workflows/docker.yml`** builds the image on pull requests without pushing, and asserts `caddy list-modules` reports `http.handlers.waf` rather than trusting a green build. Nothing built this image before, which is how it came to clone the repository instead of using the context, and to pin a stale Go version.
+- `.dockerignore` extended so the context excludes `node_modules`, `docs/`, tests and helper scripts. `ui/` is deliberately kept: `assets.go` embeds it behind the `with_ui` build tag.
+
+### Changed
+- Bumped version constant `wafVersion` to `v0.3.10`.
+
 ## [v0.3.9] - 2026-07-28
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,57 +1,60 @@
-# Use a Go base image to build the Caddy binary
-FROM golang:1.24-alpine AS builder
+# Build Caddy with the caddy-waf module.
+#
+# The build context IS the source. This previously ran `git clone` against
+# GitHub, so `docker build .` ignored your checkout entirely and compiled
+# whatever happened to be on main at that moment: not reproducible, unable to
+# build a specific version, and it would make a CI image build test the wrong
+# code.
+#
+# Cross-compilation is done by Go on the build platform rather than by emulating
+# the target, so an arm64 image does not cost a QEMU-emulated compile.
 
-# Install git and xcaddy (required for cloning the repository and building Caddy)
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
+
+# go.mod declares go 1.25.1 (propagated from caddy/v2, which requires it), so
+# the toolchain here has to be at least that. It was pinned to 1.24 and only
+# worked because GOTOOLCHAIN=auto silently downloaded a newer one mid-build.
+
 RUN apk add --no-cache git wget && \
     go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
 
-# Set the working directory inside the container
-WORKDIR /app
+WORKDIR /src
 
-# Clone the caddy-waf repository
-RUN git clone https://github.com/fabriziosalmi/caddy-waf.git
+# Warm the module cache before copying the rest, so a source-only edit does not
+# re-download the dependency tree.
+COPY go.mod go.sum ./
+RUN go mod download
 
-# Navigate into the caddy-waf directory
-WORKDIR /app/caddy-waf
+COPY . .
 
-# Clean up and update the go.mod file (dependencies are already defined in go.mod)
-RUN go mod tidy
+# GeoLite2 is optional at runtime, and this URL is a community mirror of
+# uncertain freshness (see docs/geoblocking.md). It is baked in so the country
+# and ASN examples work out of the box.
+RUN wget -q https://git.io/GeoLite2-Country.mmdb
 
-# Download the GeoLite2 Country database
-RUN wget https://git.io/GeoLite2-Country.mmdb
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
+    xcaddy build --with github.com/fabriziosalmi/caddy-waf=/src
 
-# Clean up previous build artifacts
-RUN rm -rf buildenv_*
-
-# Build Caddy with the caddy-waf module
-RUN xcaddy build --with github.com/fabriziosalmi/caddy-waf=./
-
-# ---  Runtime Stage (smaller final image) ---
+# --- Runtime ---
 FROM alpine:latest
 
-# Set the working directory
+RUN apk add --no-cache ca-certificates && \
+    addgroup -S caddy && adduser -S -G caddy caddy
+
 WORKDIR /app
 
-# Copy the built Caddy binary from the builder stage
-COPY --from=builder /app/caddy-waf/caddy /usr/bin/caddy
-
-# Copy the GeoLite2 database, rules, blacklists, and Caddyfile
-COPY --from=builder /app/caddy-waf/GeoLite2-Country.mmdb /app/
-COPY --from=builder /app/caddy-waf/rules.json /app/
-COPY --from=builder /app/caddy-waf/ip_blacklist.txt /app/
-COPY --from=builder /app/caddy-waf/dns_blacklist.txt /app/
+COPY --from=builder /src/caddy /usr/bin/caddy
+COPY --from=builder /src/GeoLite2-Country.mmdb /app/
+COPY --from=builder /src/rules.json /app/
+COPY --from=builder /src/ip_blacklist.txt /app/
+COPY --from=builder /src/dns_blacklist.txt /app/
 COPY Caddyfile /app/
 
-# Set the user to caddy for security
-RUN addgroup -S caddy && adduser -S -G caddy caddy
-
-# Change ownership of the /app to the caddy user
 RUN chown -R caddy:caddy /app
 
 USER caddy
 
-# Expose HTTP ports (adjust as needed)
 EXPOSE 8080
 
-# Run Caddy
 CMD ["caddy", "run", "--config", "/app/Caddyfile"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Web Application Firewall middleware for the [Caddy](https://caddyserver.com/) 
 
 - **Module ID**: `http.handlers.waf` — [registered in Caddy's package registry](https://caddyserver.com/docs/modules/http.handlers.waf), so `caddy add-package` and the [download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf) both work
 - **Go module path**: `github.com/fabriziosalmi/caddy-waf`
-- **Current version**: `v0.3.9` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
+- **Current version**: `v0.3.10` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
 - **License**: AGPL-3.0 — note this is a copyleft licence; check it suits your deployment before integrating
 
 ---
@@ -67,7 +67,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version  {"version":"v0.3.9"}
+INFO  WAF middleware version  {"version":"v0.3.10"}
 INFO  Rate limit configuration  {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded     {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}

--- a/caddywaf.go
+++ b/caddywaf.go
@@ -49,7 +49,7 @@ var (
 )
 
 // Add or update the version constant as needed
-const wafVersion = "v0.3.9" // update this value to the new release version when tagging
+const wafVersion = "v0.3.10" // update this value to the new release version when tagging
 
 // ==================== Initialization and Setup ====================
 

--- a/docs/add-package-guide.md
+++ b/docs/add-package-guide.md
@@ -37,7 +37,7 @@ caddy list-modules | grep waf
 ## Pin a version
 
 ```bash
-caddy add-package github.com/fabriziosalmi/caddy-waf@v0.3.9
+caddy add-package github.com/fabriziosalmi/caddy-waf@v0.3.10
 ```
 
 Any tag from the [Releases](https://github.com/fabriziosalmi/caddy-waf/releases)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -16,6 +16,8 @@ The build is a two-stage build:
 2. Clones `https://github.com/fabriziosalmi/caddy-waf.git`.
 3. Runs `go mod tidy`.
 4. Downloads the GeoLite2 Country database from `https://git.io/GeoLite2-Country.mmdb`.
+
+Note that the build context is the source tree. Before v0.3.10 the Dockerfile ran `git clone` against GitHub, so `docker build .` ignored your checkout and compiled whatever was on `main` at that moment.
 5. Compiles a Caddy binary with the WAF module via `xcaddy build --with github.com/fabriziosalmi/caddy-waf=./`.
 
 > The Dockerfile clones from GitHub regardless of the build context. To use a local checkout (e.g. with uncommitted changes) modify the Dockerfile to `COPY . /app/caddy-waf` instead of `git clone`, or build with `xcaddy` outside Docker and `COPY` the binary in.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version          {"version":"v0.3.9"}
+INFO  WAF middleware version          {"version":"v0.3.10"}
 INFO  Rate limit configuration        {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded             {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}
@@ -69,7 +69,7 @@ The module is registered in Caddy's package registry, so an existing Caddy v2.7+
 caddy add-package github.com/fabriziosalmi/caddy-waf
 ```
 
-This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.3.9` if needed.
+This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.3.10` if needed.
 
 The module is also selectable on <https://caddyserver.com/download>.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,7 +41,7 @@ A representative response:
   "dns_blacklist_hits":            0,
   "rate_limiter_requests":         27004,
   "rate_limiter_blocked_requests": 23640,
-  "version":                       "v0.3.9"
+  "version":                       "v0.3.10"
 }
 ```
 


### PR DESCRIPTION
Unblocks discussion #57, where the answer given in April pointed at `ghcr.io/fabriziosalmi/caddy-waf` — an image that was **never published**. Verified: the packages page 404s and no workflow builds one.

## The Dockerfile did not build your source

```dockerfile
RUN git clone https://github.com/fabriziosalmi/caddy-waf.git
```

`docker build .` ignored the build context entirely and compiled whatever happened to be on `main` at that moment. Consequences:

- Not reproducible — the same Dockerfile at two different times produces different binaries.
- A specific version cannot be built.
- A CI image build would have tested `main`, not the pull request.
- Local changes never reach the image, which makes `docker-compose up --build` misleading.

The build context is now the source.

## The builder was older than `go.mod` requires

`golang:1.24-alpine` against a module declaring `go 1.25.1`. It only worked because `GOTOOLCHAIN=auto` silently downloads a newer toolchain mid-build — slower, and it fails outright with `GOTOOLCHAIN=local` or without network. Now `golang:1.26-alpine`.

Cross-compilation is done by Go on the build platform (`--platform=$BUILDPLATFORM` + `GOARCH=$TARGETARCH`), so the arm64 image does not cost a QEMU-emulated `xcaddy` compile.

## The workflow

`.github/workflows/docker.yml`:

- **On pull requests**: builds without pushing, then runs `caddy list-modules` and requires `http.handlers.waf` in the output. A green build that produces an image without the WAF in it would be worse than no image — this is the same "assert the thing actually works" approach that surfaced the blacklist defects today.
- **On release tags**: pushes `linux/amd64` and `linux/arm64` to `ghcr.io/fabriziosalmi/caddy-waf`, tagged `{{version}}`, `{{major}}.{{minor}}` and `latest`.

Version tags matter here: publishing only `latest` would leave anyone who pulled before a security release with no way to name the image they actually wanted. Given today produced six advisory-covered defects, that is not hypothetical.

**Nothing built this image before.** That absence is exactly how the `git clone` and the stale Go pin survived unnoticed in a documented install path.

## `.dockerignore`

Extended for the now-larger context — `node_modules` alone is 98 MB. The two pre-existing entries are kept.

`ui/` is deliberately **not** excluded: `assets.go` embeds it behind the `with_ui` build tag. Excluding it works today, because the default build uses the stub, and would break the first `-tags with_ui` build in a way nothing would catch.

## What I could not verify

Docker is not available in my environment, so I have not built this image locally. The PR build job is the verification — which is precisely why it runs on pull requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)