### PR TITLE
docs: stop presenting add-package as an install path for caddy-waf

### DIFF
--- a/CADDY_MODULE_REGISTRATION.md
+++ b/CADDY_MODULE_REGISTRATION.md
@@ -32,6 +32,22 @@ The module documentation rendered on caddyserver.com is extracted from the
 doc comment on the `Middleware` struct in [types.go](types.go). Editing that
 comment changes what users read on Caddy's site.
 
+## Upstream may retire `add-package`
+
+Caddy's maintainers have proposed moving `add-package`, `remove-package` and
+`upgrade` out of core to discourage their use
+([caddyserver/caddy#7010](https://github.com/caddyserver/caddy/issues/7010)),
+because those commands call Caddy's shared build server and are being used in
+CI/CD. Raised for this project in
+[#138](https://github.com/fabriziosalmi/caddy-waf/issues/138) by a Caddy
+maintainer.
+
+**Registration is still worth keeping regardless.** It is what lists the module
+on <https://caddyserver.com/download> and renders its documentation page — the
+discovery surface — which is independent of whether the `add-package` command
+survives. What changed is the documentation: `xcaddy` and the container image are
+now presented as the install paths, and `add-package` as a convenience.
+
 ## Do not reintroduce `&Middleware{}`
 
 Registering a package makes the registry run a **static analyzer** over the

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Web Application Firewall middleware for the [Caddy](https://caddyserver.com/) 
 [![CodeQL](https://github.com/fabriziosalmi/caddy-waf/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/fabriziosalmi/caddy-waf/actions/workflows/github-code-scanning/codeql)
 [![Build, Run and Validate](https://github.com/fabriziosalmi/caddy-waf/actions/workflows/build-run-validate.yml/badge.svg)](https://github.com/fabriziosalmi/caddy-waf/actions/workflows/build-run-validate.yml)
 
-- **Module ID**: `http.handlers.waf` — [registered in Caddy's package registry](https://caddyserver.com/docs/modules/http.handlers.waf), so `caddy add-package` and the [download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf) both work
+- **Module ID**: `http.handlers.waf` — [registered in Caddy's package registry](https://caddyserver.com/docs/modules/http.handlers.waf), so the module is selectable on the [download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf)
 - **Go module path**: `github.com/fabriziosalmi/caddy-waf`
 - **Current version**: `v0.3.10` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
 - **License**: AGPL-3.0 — note this is a copyleft licence; check it suits your deployment before integrating
@@ -114,6 +114,19 @@ xcaddy build --with github.com/fabriziosalmi/caddy-waf=./
 ```
 
 ### Method 4 — `caddy add-package`
+
+> [!IMPORTANT]
+> **Prefer `xcaddy` or the container image.** Caddy's maintainers have proposed
+> moving `add-package`, `remove-package` and `upgrade` out of Caddy's core to
+> discourage their use ([caddyserver/caddy#7010](https://github.com/caddyserver/caddy/issues/7010)):
+> the commands call Caddy's shared build server, and using them in CI/CD is an
+> anti-pattern. Raised for this project in
+> [#138](https://github.com/fabriziosalmi/caddy-waf/issues/138) by a Caddy
+> maintainer.
+>
+> The command works today and the module remains registered, so this section
+> stays accurate. Treat it as a convenience for one-off, hand-operated installs
+> — not as the way to build or deploy caddy-waf.
 
 The module is registered in Caddy's package registry, so an existing Caddy v2.7+ binary can pull it in without a Go toolchain:
 

--- a/docs/add-package-guide.md
+++ b/docs/add-package-guide.md
@@ -1,5 +1,22 @@
 # `caddy add-package`
 
+> [!IMPORTANT]
+> **This is not the recommended way to install caddy-waf.** Caddy's maintainers
+> have proposed moving `add-package`, `remove-package` and `upgrade` out of
+> Caddy's core to discourage their use
+> ([caddyserver/caddy#7010](https://github.com/caddyserver/caddy/issues/7010)):
+> the commands call Caddy's shared build server, and periodic use from CI/CD is
+> an anti-pattern. Raised for this project in
+> [#138](https://github.com/fabriziosalmi/caddy-waf/issues/138) by a Caddy
+> maintainer.
+>
+> Build with [`xcaddy`](installation.md#method-1--build-with-xcaddy-recommended)
+> or run the [container image](installation.md#method-5--docker) instead. Both
+> are reproducible, pinnable, and do not depend on someone else's build service.
+>
+> The command still works and the module remains registered, so this page is
+> accurate — treat it as a convenience for a one-off, hand-operated install.
+
 `github.com/fabriziosalmi/caddy-waf` is registered in Caddy's package registry
 (since 2026-07-28), so it can be added to an existing Caddy binary without a Go
 toolchain. It is also selectable on <https://caddyserver.com/download>.

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,20 +51,22 @@ features:
 
 ## Install
 
-The module is registered in Caddy's package registry, so an existing Caddy v2.7+ binary can pull it in without a Go toolchain:
-
-```bash
-caddy add-package github.com/fabriziosalmi/caddy-waf
-caddy list-modules | grep waf    # http.handlers.waf
-```
-
-Or build it yourself with [`xcaddy`](https://github.com/caddyserver/xcaddy):
+Build a Caddy binary with the module using [`xcaddy`](https://github.com/caddyserver/xcaddy):
 
 ```bash
 xcaddy build --with github.com/fabriziosalmi/caddy-waf
+./caddy list-modules | grep waf    # http.handlers.waf
 ```
 
-It is also selectable on the [Caddy download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf). See [Installation](installation.md) for every supported path.
+Or run the published container image, which needs no Go toolchain:
+
+```bash
+docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.3.10
+```
+
+The module is also selectable on the [Caddy download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf), and `caddy add-package github.com/fabriziosalmi/caddy-waf` works for a one-off install — though Caddy's maintainers have proposed moving that command out of core, so do not build a deployment around it ([#138](https://github.com/fabriziosalmi/caddy-waf/issues/138)).
+
+See [Installation](installation.md) for every supported path.
 
 ## Minimal configuration
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -63,6 +63,19 @@ The `=./` form of `--with` instructs `xcaddy` to use the local checkout rather t
 
 ## Method 4 — `caddy add-package`
 
+> [!IMPORTANT]
+> **Prefer `xcaddy` or the container image.** Caddy's maintainers have proposed
+> moving `add-package`, `remove-package` and `upgrade` out of Caddy's core to
+> discourage their use ([caddyserver/caddy#7010](https://github.com/caddyserver/caddy/issues/7010)):
+> the commands call Caddy's shared build server, and using them in CI/CD is an
+> anti-pattern. Raised for this project in
+> [#138](https://github.com/fabriziosalmi/caddy-waf/issues/138) by a Caddy
+> maintainer.
+>
+> The command works today and the module remains registered, so this section
+> stays accurate. Treat it as a convenience for one-off, hand-operated installs
+> — not as the way to build or deploy caddy-waf.
+
 The module is registered in Caddy's package registry, so an existing Caddy v2.7+ binary can pull it in without a Go toolchain:
 
 ```bash


### PR DESCRIPTION
Closes #138.

@mohammed90 (Caddy maintainer) asked us not to depend on `add-package`: the maintainers have proposed moving it, `remove-package` and `upgrade` out of Caddy's core to discourage use, because those commands call Caddy's shared build server and periodic CI/CD use is an anti-pattern — [caddyserver/caddy#7010](https://github.com/caddyserver/caddy/issues/7010).

## What I verified first

Nothing is broken, so nothing is removed:

```
GET /api/download?p=github.com%2Ffabriziosalmi%2Fcaddy-waf   -> HTTP 200 (binary)
GET /api/packages?q=caddy-waf                                -> listed=True available=True downloads=16
```

The command works and the module is registered. The problem is not accuracy, it is **prominence** — what the docs put in front of a reader.

## Changes

| Where | Before | After |
|---|---|---|
| `docs/index.md` (site home) | Install section **opened** with `caddy add-package` | Opens with `xcaddy`, then the container image; `add-package` mentioned after, with the caveat |
| `README.md` header | "…so `caddy add-package` and the download page both work" | mentions only the download page — the part of registration not in question |
| README / `installation.md` / `add-package-guide.md` | no caveat | `> [!IMPORTANT]` note pointing at #7010 and at `xcaddy` / the image |

The alert renders natively on both surfaces — GitHub markdown, and VitePress emits `<div class="important custom-block github-alert">`. Checked against the built HTML rather than assumed.

## What is deliberately *not* changed

**Registration stays.** It is what lists the module on [caddyserver.com/download](https://caddyserver.com/download) and renders its [documentation page](https://caddyserver.com/docs/modules/http.handlers.waf) — the discovery surface, and independent of whether the `add-package` command survives. Recorded in `CADDY_MODULE_REGISTRATION.md` so the reasoning is not lost if #7010 lands.

**Method numbering.** Renumbering so `add-package` sorts last would move the heading anchors, and other pages link to them. It is already Method 4 of 5, and the caveat carries the message. The site homepage was the real offender and that is fixed.

Docs build clean, anchors validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)