### PR TITLE
fix: metrics endpoint raced on shared counters and corrupted its response

### DIFF
--- a/caddywaf.go
+++ b/caddywaf.go
@@ -595,18 +595,48 @@ func (m *Middleware) handleMetricsRequest(w http.ResponseWriter, r *http.Request
 	// Collect rule hits using getRuleHitStats
 	ruleHits := m.getRuleHitStats()
 
+	// Snapshot the shared counters under the locks that guard their writers.
+	//
+	// These used to be read straight off the struct, which raced with every
+	// in-flight request. rule_hits_by_phase made it worse than a benign race:
+	// it is a map, and it was handed to json.Marshal by reference, so the
+	// marshal iterated it while requests wrote to it. Go's runtime answers that
+	// with "concurrent map read and map write" -- a throw, not a data race the
+	// program can shrug off -- which ServeHTTP's panic recovery then turns into
+	// a 500. Scraping metrics under traffic could take out requests, which also
+	// made the endpoint unusable as the source for any dashboard.
+	m.muMetrics.RLock()
+	totalRequests := m.totalRequests
+	blockedRequests := m.blockedRequests
+	allowedRequests := m.allowedRequests
+	geoIPBlocked := m.geoIPBlocked
+	hitsByPhase := make(map[int]int64, len(m.ruleHitsByPhase))
+	for phase, hits := range m.ruleHitsByPhase {
+		hitsByPhase[phase] = hits
+	}
+	m.muMetrics.RUnlock()
+
+	// The blacklist counters have their own mutexes.
+	m.muIPBlacklistMetrics.Lock()
+	ipBlacklistHits := m.IPBlacklistBlockCount
+	m.muIPBlacklistMetrics.Unlock()
+
+	m.muDNSBlacklistMetrics.Lock()
+	dnsBlacklistHits := m.DNSBlacklistBlockCount
+	m.muDNSBlacklistMetrics.Unlock()
+
 	// Collect all metrics
 	metrics := map[string]interface{}{
-		"total_requests":                m.totalRequests,
-		"blocked_requests":              m.blockedRequests,
-		"allowed_requests":              m.allowedRequests,
+		"total_requests":                totalRequests,
+		"blocked_requests":              blockedRequests,
+		"allowed_requests":              allowedRequests,
 		"rule_hits":                     ruleHits,
-		"rule_hits_by_phase":            m.ruleHitsByPhase,          // Include rule hits by phase
-		"geoip_blocked":                 m.geoIPBlocked,             // Add the new geoIPBlocked metric
-		"ip_blacklist_hits":             m.IPBlacklistBlockCount,    // Add IP blacklist hits metric
-		"dns_blacklist_hits":            m.DNSBlacklistBlockCount,   // Add DNS blacklist hits metric
-		"rate_limiter_requests":         rateLimiterTotalRequests,   // Add rate limiter total requests
-		"rate_limiter_blocked_requests": rateLimiterBlockedRequests, // Add rate limiter blocked requests
+		"rule_hits_by_phase":            hitsByPhase,
+		"geoip_blocked":                 geoIPBlocked,
+		"ip_blacklist_hits":             ipBlacklistHits,
+		"dns_blacklist_hits":            dnsBlacklistHits,
+		"rate_limiter_requests":         rateLimiterTotalRequests,
+		"rate_limiter_blocked_requests": rateLimiterBlockedRequests,
 		"version":                       wafVersion,
 	}
 

--- a/handler.go
+++ b/handler.go
@@ -68,6 +68,25 @@ func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next cadd
 		return nil // Request blocked, short-circuit
 	}
 
+	// Serve the metrics document before touching the upstream.
+	//
+	// This check used to sit after next.ServeHTTP, which only appeared to work:
+	// the recorder buffered unconditionally, so the upstream's body went into a
+	// buffer that the metrics path never copied out, and the JSON came back
+	// clean by accident. Once the recorder became a pass-through when no Phase 4
+	// rule is loaded (v0.3.4), the upstream body started going straight to the
+	// client with the metrics JSON appended after it -- a corrupt response
+	// served as application/json. It also called the upstream for every scrape,
+	// which is work no one asked for.
+	//
+	// It sits after Phase 1 and 2 on purpose: the IP blacklist, the rate limiter
+	// and the request rules still apply, so the endpoint can be protected.
+	if m.isMetricsRequest(r) {
+		m.incrementAllowedRequestsMetric()
+		m.logRequestCompletion(logID, state)
+		return m.handleMetricsRequest(w, r)
+	}
+
 	// Response capture and processing. The body is only buffered when Phase 4
 	// rules exist to inspect it, and never past MaxResponseBodySize, so a large
 	// or streaming upstream response cannot drive the process out of memory.
@@ -90,11 +109,6 @@ func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next cadd
 		// the client.
 		m.writeCustomResponse(w, state.StatusCode)
 		return nil
-	}
-
-	// Handle metrics request separately
-	if m.isMetricsRequest(r) {
-		return m.handleMetricsRequest(w, r)
 	}
 
 	// If not blocked, copy recorded response back to original writer

--- a/metrics_concurrency_test.go
+++ b/metrics_concurrency_test.go
@@ -1,0 +1,104 @@
+package caddywaf
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"sync"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/phemmer/go-iptrie"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestMetricsEndpointUnderConcurrentTraffic guards the metrics handler against
+// reading the shared counters without synchronisation.
+//
+// The counters were read straight off the struct while every request wrote to
+// them. rule_hits_by_phase made that more than a benign race: it is a map, and
+// it was passed to json.Marshal by reference, so the marshal iterated it while
+// requests mutated it. Go answers that with "concurrent map read and map write",
+// a runtime throw, which ServeHTTP's panic recovery converts into a 500 -- so
+// scraping metrics under load could take out requests.
+//
+// Run with -race for this to be meaningful; the map case can also fail outright.
+func TestMetricsEndpointUnderConcurrentTraffic(t *testing.T) {
+	logger := zap.NewNop()
+	m := &Middleware{
+		logger:           logger,
+		blacklistLoader:  NewBlacklistLoader(logger),
+		MetricsEndpoint:  "/waf_metrics",
+		AnomalyThreshold: 1000, // score, never block: we want counters moving
+		ruleCache:        NewRuleCache(),
+		ipBlacklist:      iptrie.NewTrie(),
+		dnsBlacklist:     map[string]struct{}{},
+		ruleHitsByPhase:  map[int]int64{},
+		// A matching rule on every request keeps ruleHitsByPhase being written.
+		Rules: map[int][]Rule{1: {{
+			ID: "probe", Pattern: "probe", Targets: []string{"URI"},
+			Phase: 1, Score: 1, Action: "log", regex: regexp.MustCompile("probe"),
+		}}},
+		requestValueExtractor: NewRequestValueExtractor(logger, false, 0),
+	}
+
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		_, err := w.Write([]byte("ok"))
+		return err
+	})
+
+	const (
+		writers   = 8
+		readers   = 4
+		perWriter = 60
+		perReader = 40
+	)
+
+	var wg sync.WaitGroup
+	scrapes := make(chan []byte, readers*perReader)
+
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perWriter; j++ {
+				req := httptest.NewRequest(http.MethodGet, testURL+"/?q=probe", nil)
+				req.RemoteAddr = "203.0.113.7:1234"
+				_ = m.ServeHTTP(httptest.NewRecorder(), req, next)
+			}
+		}()
+	}
+
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perReader; j++ {
+				req := httptest.NewRequest(http.MethodGet, testURL+"/waf_metrics", nil)
+				req.RemoteAddr = "203.0.113.8:1234"
+				w := httptest.NewRecorder()
+				_ = m.ServeHTTP(w, req, next)
+				scrapes <- w.Body.Bytes()
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(scrapes)
+
+	// Every scrape must be a 200 with parseable JSON. A panic recovered by
+	// ServeHTTP would surface as a 500 with a plain-text body.
+	checked := 0
+	for body := range scrapes {
+		var payload map[string]any
+		require.NoErrorf(t, json.Unmarshal(body, &payload),
+			"metrics response was not JSON: %q", string(body))
+		assert.Contains(t, payload, "rule_hits_by_phase")
+		assert.Contains(t, payload, "total_requests")
+		checked++
+	}
+	require.Equal(t, readers*perReader, checked)
+}


### PR DESCRIPTION
Two defects on `/waf_metrics`. Both were found by writing a concurrency test, not by reading the code.

## 1. Unsynchronised reads — one of them a runtime throw, not a race

The handler read six shared fields straight off the struct while every request wrote to them under `muMetrics`:

```go
"total_requests":     m.totalRequests,
"rule_hits_by_phase": m.ruleHitsByPhase,   // <- a map, passed by reference
"geoip_blocked":      m.geoIPBlocked,
...
```

`rule_hits_by_phase` is the dangerous one. It is a `map[int]int64`, handed to `json.Marshal` **by reference**, so the marshal iterates it while requests mutate it (`rules.go` writes it under `muMetrics.Lock()`). Go's answer to that is `concurrent map read and map write` — a **runtime throw**, not a data race the program shrugs off. `ServeHTTP`'s panic recovery turns it into a `500`.

So scraping metrics under traffic could take out requests. It also made the endpoint unusable as a data source for a dashboard, which is the reason I went looking.

Everything is now snapshotted under the locks that guard the writers, with the map **copied** rather than shared. The two blacklist counters have their own mutexes and are taken separately.

## 2. A scrape called the upstream, and its body was prepended to the JSON

`isMetricsRequest` sat **after** `next.ServeHTTP`:

```go
recorder := NewResponseRecorderWithLimit(...)
err := next.ServeHTTP(recorder, r)     // upstream runs, writes its body
...
if m.isMetricsRequest(r) {
    return m.handleMetricsRequest(w, r)  // JSON appended after it
}
```

Observed response body, served as `application/json`:

```
ok{"allowed_requests":11,"blocked_requests":0,...}
```

**I introduced this in v0.3.4.** Before `050f9df` the recorder buffered unconditionally, so the upstream's body went into a buffer the metrics path never copied out — the JSON came back clean *by accident*. Making the recorder a pass-through when no Phase 4 rule is loaded exposed it.

The check now runs **before** the recorder exists, and deliberately **after** Phase 1 and 2, so the IP blacklist, rate limiter and request rules still protect the endpoint. It also stops calling the upstream for every scrape.

## Test, and each fix proven in isolation

`metrics_concurrency_test.go` — 8 writers driving traffic through `ServeHTTP`, 4 readers scraping, every scrape required to be parseable JSON containing the expected keys.

| State | Result |
|---|---|
| Both fixes | `ok` |
| Ordering fix only, unsynchronised reads | `-race`: **WARNING: DATA RACE** ×5 |
| Locks only, old ordering | body is `ok{…json…}` → **not JSON** |

Full suite green under `-race` (12.7s).

## Note on the dashboard work

This is a prerequisite for rebuilding the UI: the endpoint it reads had to stop crashing under load and stop emitting invalid JSON first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)