### PR TITLE
feat: whitelist_ip — exempt addresses from the IP-reputation checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.3.11] - 2026-08-18
+
+### Added
+- **`whitelist_ip` — exempt addresses from the IP-reputation checks without switching the WAF off for them.** Accepts bare IPs, CIDR ranges, or the token `private_ranges`, and is repeatable:
+
+  ```caddyfile
+  whitelist_ip private_ranges
+  whitelist_ip 203.0.113.4 198.51.100.0/24
+  ```
+
+  Requested in [#137](https://github.com/fabriziosalmi/caddy-waf/issues/137) by [@nozonyan](https://github.com/nozonyan): `whitelist_countries` blocks anything it cannot geolocate, which includes every address on the local network, so enabling it locks you out of your own service from inside the LAN. The only workarounds were `geoip_fail_open` — which also admits every unresolvable *public* address — or maintaining two site blocks with separate rule sets, with the risk of leaving the public one unprotected after a test.
+
+  The exemption covers the checks that judge a client by where it comes from: the **IP blacklist** (including Tor exit nodes fed into it), **`whitelist_countries` / `block_countries`**, and **`block_asns`**. It deliberately does **not** cover the DNS blacklist (which judges the requested host, not the client), the rate limiter, or the regex rules in any phase. Exempting an address from geolocation is the fix; stopping inspection of its requests is not.
+
+  `private_ranges` expands to exactly the set Caddy uses for its own placeholder — `192.168.0.0/16`, `172.16.0.0/12`, `10.0.0.0/8`, `127.0.0.1/8`, `fd00::/8`, `::1`. Identical rather than "improved": a WAF and the server in front of it disagreeing about which addresses are private is how bypasses get built. An entry that does not parse fails startup rather than being skipped with a warning.
+
+### Security notes on the design
+- **The whitelist matches the peer address only, never `X-Forwarded-For`.** This is the deliberate opposite of the blacklist, which checks the peer address *and* every forwarded hop. When blocking, consulting extra addresses can only block more; when allowing, honouring a client-supplied header would let anyone send `X-Forwarded-For: 10.0.0.1` and exempt themselves from the blacklist, the country filter and the ASN filter in a single header. Covered by `TestWhitelistIgnoresForwardedHeaders`.
+- **`private_ranges` is only safe when caddy-waf is the edge.** Because the check is on the peer address, running behind another proxy makes the peer that proxy — typically a private or loopback address — which would exempt every request passing through it. The WAF now logs a warning at startup when `private_ranges` is whitelisted, and `docs/configuration.md` documents the trap.
+
+### Changed
+- Bumped version constant `wafVersion` to `v0.3.11`.
+
 ## [v0.3.10] - 2026-07-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Web Application Firewall middleware for the [Caddy](https://caddyserver.com/) 
 
 - **Module ID**: `http.handlers.waf` — [registered in Caddy's package registry](https://caddyserver.com/docs/modules/http.handlers.waf), so the module is selectable on the [download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf)
 - **Go module path**: `github.com/fabriziosalmi/caddy-waf`
-- **Current version**: `v0.3.10` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
+- **Current version**: `v0.3.11` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
 - **License**: AGPL-3.0 — note this is a copyleft licence; check it suits your deployment before integrating
 
 ---
@@ -67,7 +67,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version  {"version":"v0.3.10"}
+INFO  WAF middleware version  {"version":"v0.3.11"}
 INFO  Rate limit configuration  {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded     {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}
@@ -142,11 +142,11 @@ It is also selectable on [caddyserver.com/download](https://caddyserver.com/down
 Images are published to GitHub Container Registry on every release tag, for `linux/amd64` and `linux/arm64`:
 
 ```bash
-docker pull ghcr.io/fabriziosalmi/caddy-waf:0.3.10
-docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.3.10
+docker pull ghcr.io/fabriziosalmi/caddy-waf:0.3.11
+docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.3.11
 ```
 
-Tags are `0.3.10`, `0.3` and `latest` — note there is **no `v` prefix**, unlike the Go module version. Pin an exact version in anything you deploy. See [`docs/docker.md`](docs/docker.md) for volumes, Compose, and hot reload.
+Tags are `0.3.11`, `0.3` and `latest` — note there is **no `v` prefix**, unlike the Go module version. Pin an exact version in anything you deploy. See [`docs/docker.md`](docs/docker.md) for volumes, Compose, and hot reload.
 
 ---
 

--- a/caddywaf.go
+++ b/caddywaf.go
@@ -49,7 +49,7 @@ var (
 )
 
 // Add or update the version constant as needed
-const wafVersion = "v0.3.10" // update this value to the new release version when tagging
+const wafVersion = "v0.3.11" // update this value to the new release version when tagging
 
 // ==================== Initialization and Setup ====================
 
@@ -268,6 +268,31 @@ func (m *Middleware) Provision(ctx caddy.Context) error {
 		err = m.loadIPBlacklist(m.IPBlacklistFile, m.ipBlacklist)
 		if err != nil {
 			return fmt.Errorf("failed to load IP blacklist: %w", err)
+		}
+	}
+
+	// Build the IP whitelist
+	if len(m.IPWhitelist) > 0 {
+		trie, expanded, err := buildIPWhitelist(m.IPWhitelist)
+		if err != nil {
+			return err
+		}
+		m.ipWhitelist = trie
+		m.logger.Info("IP whitelist loaded",
+			zap.Int("entries", len(expanded)),
+			zap.Strings("ranges", expanded),
+		)
+
+		// Warn loudly when private ranges are exempt. The whitelist matches on
+		// the peer address, which is correct when caddy-waf is the edge but
+		// means the peer is the *proxy* when it is not -- and a proxy on
+		// localhost or a private network would exempt every request passing
+		// through it, silently turning these controls off.
+		for _, entry := range m.IPWhitelist {
+			if strings.EqualFold(strings.TrimSpace(entry), PrivateRangesToken) {
+				m.logger.Warn("whitelist_ip includes private_ranges: requests whose PEER address is private are exempt from the IP blacklist, country filter and ASN filter. This is only what you want if caddy-waf is the edge. Behind another proxy the peer is that proxy, which would exempt all traffic.")
+				break
+			}
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -157,7 +157,8 @@ func (cl *ConfigLoader) UnmarshalCaddyfile(d *caddyfile.Dispenser, m *Middleware
 		"log_severity":           cl.parseLogSeverity,
 		"log_json":               cl.parseLogJSON,
 		"rule_file":              cl.parseRuleFile,
-		"ip_blacklist_file":      cl.parseBlacklistFileDirective(true),  // Use directive-specific helper
+		"ip_blacklist_file":      cl.parseBlacklistFileDirective(true), // Use directive-specific helper
+		"whitelist_ip":           cl.parseWhitelistIP,
 		"dns_blacklist_file":     cl.parseBlacklistFileDirective(false), // Use directive-specific helper
 		"anomaly_threshold":      cl.parseAnomalyThreshold,
 		"custom_response":        cl.parseCustomResponse,
@@ -487,6 +488,27 @@ func (cl *ConfigLoader) parseMaxResponseBodySize(d *caddyfile.Dispenser, m *Midd
 	}
 	m.MaxResponseBodySize = size
 	cl.logger.Debug("Max response body size set", zap.Int64("bytes", size), zap.String("file", d.File()), zap.Int("line", d.Line()))
+	return nil
+}
+
+// parseWhitelistIP parses the whitelist_ip directive.
+//
+//	whitelist_ip private_ranges 203.0.113.4 198.51.100.0/24
+//
+// Repeatable; entries accumulate. Values are validated at Provision time by
+// buildIPWhitelist, so a typo fails startup rather than silently leaving an
+// address unprotected -- or, worse, unexempted.
+func (cl *ConfigLoader) parseWhitelistIP(d *caddyfile.Dispenser, m *Middleware) error {
+	entries := d.RemainingArgs()
+	if len(entries) == 0 {
+		return d.Err("whitelist_ip requires at least one IP, CIDR range, or the token private_ranges")
+	}
+	m.IPWhitelist = append(m.IPWhitelist, entries...)
+	cl.logger.Debug("IP whitelist entries added",
+		zap.Strings("entries", entries),
+		zap.String("file", d.File()),
+		zap.Int("line", d.Line()),
+	)
 	return nil
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
     # Pin an exact release rather than `latest`: this project has shipped
     # security fixes, and `latest` leaves no way to name the image you tested
     # against. Swap for `build: .` to run your local checkout instead -- since
-    # v0.3.10 that actually compiles the working tree.
-    image: ghcr.io/fabriziosalmi/caddy-waf:0.3.10
+    # v0.3.11 that actually compiles the working tree.
+    image: ghcr.io/fabriziosalmi/caddy-waf:0.3.11
     # build: .
     ports:
       - "8080:8080"

--- a/docs/add-package-guide.md
+++ b/docs/add-package-guide.md
@@ -54,7 +54,7 @@ caddy list-modules | grep waf
 ## Pin a version
 
 ```bash
-caddy add-package github.com/fabriziosalmi/caddy-waf@v0.3.10
+caddy add-package github.com/fabriziosalmi/caddy-waf@v0.3.11
 ```
 
 Any tag from the [Releases](https://github.com/fabriziosalmi/caddy-waf/releases)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,7 @@ For each incoming request, [`Middleware.ServeHTTP`](https://github.com/fabrizios
 
 The order below reflects the actual code in [`handler.go`](https://github.com/fabriziosalmi/caddy-waf/blob/main/handler.go) (`handlePhase`, `phase==1`):
 
+0. **IP whitelist** — when `whitelist_ip` is configured and the **peer address** matches, steps 1, 4, 5 and 6 below are skipped. See [IP whitelist](#ip-whitelist).
 1. **IP blacklist** — always checks `r.RemoteAddr`, plus every `X-Forwarded-For` hop in addition. Match → `403`.
 2. **DNS blacklist** — exact (case-insensitive) match against `r.Host`. Match → `403`.
 3. **Rate limit** — when configured. Exceeded → `429 Too Many Requests`.
@@ -53,6 +54,7 @@ Within each phase the runtime iterates over the rules already sorted by descendi
 ### Blocking precedence summary
 
 ```
+IP whitelist          (Phase 1, first)          — exempts the four IP-reputation checks below
 IP blacklist          (Phase 1, before rules)
 DNS blacklist         (Phase 1, before rules)
 Rate limit            (Phase 1, before rules)
@@ -87,6 +89,7 @@ The full list is the `directiveHandlers` map in [`config.go`](https://github.com
 | `rule_file` | `<file>` | none | Path to a JSON rule file. Repeat the directive to load multiple files. At least one `rule_file` is required. |
 | `ip_blacklist_file` | `<file>` | unset | Path to the IP blacklist (single IPs and CIDR ranges). The file is created empty if it does not exist. |
 | `dns_blacklist_file` | `<file>` | unset | Path to the DNS blacklist (one host per line). The file is created empty if it does not exist. |
+| `whitelist_ip` | `<entry> [<entry> …]` | unset | IPs, CIDR ranges, or the token `private_ranges`, exempt from the **IP-reputation** checks. Repeatable. See [IP whitelist](#ip-whitelist). |
 | `anomaly_threshold` | `<positive int>` | `5` (Caddyfile) / `20` (Provision fallback) | Score at which a request is blocked. Lower values are stricter. |
 | `max_request_body_size` | `<bytes>` | `10485760` (10 MiB) | Upper bound for request body reads via `io.LimitReader`. `0` means "use the default". |
 | `max_response_body_size` | `<bytes>` | `10485760` (10 MiB) | Upper bound on how much of the response body is held in memory for Phase 4 inspection. `0` means "use the default". See [Response body buffering](#response-body-buffering). |
@@ -201,6 +204,85 @@ A JSON config snippet equivalent to the minimal Caddyfile:
   "geoip_fail_open": true
 }
 ```
+
+---
+
+## IP whitelist
+
+`whitelist_ip` exempts an address from the checks that judge a client by *where
+it comes from*, without switching the WAF off for it.
+
+```caddyfile
+waf {
+    rule_file rules.json
+
+    # The token expands to Caddy's own private_ranges set.
+    whitelist_ip private_ranges
+
+    # Bare IPs and CIDR ranges work too, and the directive is repeatable.
+    whitelist_ip 203.0.113.4 198.51.100.0/24
+}
+```
+
+`private_ranges` expands to exactly the set Caddy uses for its own placeholder:
+`192.168.0.0/16`, `172.16.0.0/12`, `10.0.0.0/8`, `127.0.0.1/8`, `fd00::/8`,
+`::1`. Deliberately identical rather than "improved" — a WAF and the server in
+front of it disagreeing about which addresses are private is how bypasses get
+built.
+
+An entry that does not parse fails startup. It is not skipped with a warning:
+silently dropping an entry leaves the operator believing an address is exempt
+when it is not.
+
+### What the exemption covers
+
+| Check | Exempt? |
+|---|---|
+| IP blacklist (including Tor exit nodes fed into it) | **yes** |
+| `whitelist_countries` / `block_countries` (GeoIP) | **yes** |
+| `block_asns` | **yes** |
+| DNS blacklist | no — it judges the requested host, not the client |
+| Rate limiting | no |
+| Regex rules, all four phases | no |
+
+This is the point of the feature rather than a limitation. The case it solves
+([#137](https://github.com/fabriziosalmi/caddy-waf/issues/137)) is a private
+address being blocked by `whitelist_countries` because it has no geolocation.
+The answer to that is to exempt it from geolocation — not to stop inspecting its
+requests.
+
+Previously the only workaround was `geoip_fail_open`, which lets *every*
+unresolvable address through, or maintaining two site blocks with separate rule
+sets.
+
+### It matches the peer address only
+
+The whitelist reads `r.RemoteAddr` and **never** `X-Forwarded-For`. That is the
+opposite of the blacklist, which checks the peer address *and* every forwarded
+hop, and the asymmetry is deliberate:
+
+- When **blocking**, consulting extra addresses can only block more. Safe.
+- When **allowing**, honouring a client-supplied header would let anyone send
+  `X-Forwarded-For: 10.0.0.1` and exempt themselves from the blacklist, the
+  country filter and the ASN filter in one move.
+
+The peer address is the only value a client cannot forge, so it is the only one
+trusted here.
+
+> [!WARNING]
+> **`private_ranges` is only safe when caddy-waf is the edge.**
+>
+> Because the check is on the peer address, running caddy-waf *behind* another
+> proxy means the peer is that proxy — typically a loopback or private address.
+> Whitelisting `private_ranges` would then exempt **every** request arriving
+> through it, silently disabling the IP blacklist, the country filter and the ASN
+> filter for all traffic.
+>
+> The WAF logs a warning at startup when `private_ranges` is whitelisted, for
+> exactly this reason. If caddy-waf sits behind a proxy, list the specific
+> addresses you mean instead, and see
+> [#94](https://github.com/fabriziosalmi/caddy-waf/issues/94) for the
+> `trusted_proxies` work that will make forwarded addresses usable.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,10 +279,18 @@ trusted here.
 > filter for all traffic.
 >
 > The WAF logs a warning at startup when `private_ranges` is whitelisted, for
-> exactly this reason. If caddy-waf sits behind a proxy, list the specific
-> addresses you mean instead, and see
-> [#94](https://github.com/fabriziosalmi/caddy-waf/issues/94) for the
-> `trusted_proxies` work that will make forwarded addresses usable.
+> exactly this reason.
+>
+> **Listing specific client addresses is not a workaround.** Behind a proxy the
+> peer address is *always* that proxy, so no entry naming a real client will ever
+> match — the only address `whitelist_ip` can match is the proxy itself, which
+> exempts all traffic through it. In that topology the directive cannot express
+> "exempt this client" at all.
+>
+> Until [#94](https://github.com/fabriziosalmi/caddy-waf/issues/94) adds
+> `trusted_proxies`, and with it a defensible way to act on forwarded addresses,
+> the options behind a proxy are: leave `whitelist_ip` unset, or place the WAF at
+> the edge where the peer address is the client.
 
 ---
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,16 +7,16 @@ The repository ships a [`Dockerfile`](https://github.com/fabriziosalmi/caddy-waf
 Images are published to GitHub Container Registry on every release tag, for `linux/amd64` and `linux/arm64`:
 
 ```bash
-docker pull ghcr.io/fabriziosalmi/caddy-waf:0.3.10
+docker pull ghcr.io/fabriziosalmi/caddy-waf:0.3.11
 ```
 
 | Tag | Meaning |
 |---|---|
-| `0.3.10` | An exact release. **Prefer this.** |
+| `0.3.11` | An exact release. **Prefer this.** |
 | `0.3` | Latest patch of the 0.3 line. |
 | `latest` | Latest release, whatever it currently is. |
 
-Note the image tag carries **no `v` prefix**, unlike the Go module version: `caddy add-package …@v0.3.10` but `docker pull …:0.3.10`.
+Note the image tag carries **no `v` prefix**, unlike the Go module version: `caddy add-package …@v0.3.11` but `docker pull …:0.3.11`.
 
 Pin an exact version in anything you deploy. `latest` gives you no way to name the image you tested against, which matters when a release fixes a security defect — see [Security → Advisories](https://github.com/fabriziosalmi/caddy-waf/security/advisories).
 
@@ -28,7 +28,7 @@ docker build -t caddy-waf .
 
 The build context is the source tree, so this compiles your checkout, uncommitted changes included.
 
-> Before **v0.3.10** it did not. The Dockerfile ran `git clone https://github.com/fabriziosalmi/caddy-waf.git` and built that, so `docker build .` ignored the context entirely and produced an image containing whatever was on `main` at that moment — not reproducible, impossible to pin to a version, and silently useless for testing a local change.
+> Before **v0.3.11** it did not. The Dockerfile ran `git clone https://github.com/fabriziosalmi/caddy-waf.git` and built that, so `docker build .` ignored the context entirely and produced an image containing whatever was on `main` at that moment — not reproducible, impossible to pin to a version, and silently useless for testing a local change.
 
 Two stages:
 
@@ -39,7 +39,7 @@ Two stages:
 3. Downloads the GeoLite2 Country database from `https://git.io/GeoLite2-Country.mmdb` (a community mirror — see [geoblocking.md](geoblocking.md)).
 4. Cross-compiles with `GOARCH=$TARGETARCH` on the build platform, so an arm64 image costs no emulated compile.
 
-The builder image must be at least the Go version `go.mod` declares (`1.25.1`, propagated from `caddy/v2`). It was pinned to `1.24` until v0.3.10 and only worked because `GOTOOLCHAIN=auto` downloaded a newer toolchain mid-build.
+The builder image must be at least the Go version `go.mod` declares (`1.25.1`, propagated from `caddy/v2`). It was pinned to `1.24` until v0.3.11 and only worked because `GOTOOLCHAIN=auto` downloaded a newer toolchain mid-build.
 
 ### Stage 2 — runtime (`alpine:latest`)
 

--- a/docs/geoblocking.md
+++ b/docs/geoblocking.md
@@ -34,6 +34,15 @@ GeoIP lookups use `getClientIP` ([`helpers.go`](https://github.com/fabriziosalmi
 
 The host portion is then extracted (port stripped) and passed to the MMDB reader.
 
+> [!TIP]
+> **Private and unresolvable addresses.** `whitelist_countries` blocks anything it
+> cannot geolocate, which includes every address on your LAN — so enabling it can
+> lock you out of your own service from inside the network. Use
+> [`whitelist_ip private_ranges`](configuration.md#ip-whitelist) to exempt those
+> addresses from geolocation while keeping the rule engine and rate limiter
+> applied to them. `geoip_fail_open` also unblocks them, but it unblocks every
+> unresolvable public address as well.
+
 ## Evaluation order in Phase 1
 
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ xcaddy build --with github.com/fabriziosalmi/caddy-waf
 Or run the published container image, which needs no Go toolchain:
 
 ```bash
-docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.3.10
+docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.3.11
 ```
 
 The module is also selectable on the [Caddy download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf), and `caddy add-package github.com/fabriziosalmi/caddy-waf` works for a one-off install — though Caddy's maintainers have proposed moving that command out of core, so do not build a deployment around it ([#138](https://github.com/fabriziosalmi/caddy-waf/issues/138)).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version          {"version":"v0.3.10"}
+INFO  WAF middleware version          {"version":"v0.3.11"}
 INFO  Rate limit configuration        {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded             {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}
@@ -82,7 +82,7 @@ The module is registered in Caddy's package registry, so an existing Caddy v2.7+
 caddy add-package github.com/fabriziosalmi/caddy-waf
 ```
 
-This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.3.10` if needed.
+This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.3.11` if needed.
 
 The module is also selectable on <https://caddyserver.com/download>.
 
@@ -93,16 +93,16 @@ See [add-package-guide.md](add-package-guide.md) for the full flow, removal, and
 Images are published to GitHub Container Registry on every release tag, for `linux/amd64` and `linux/arm64`. No Go toolchain, no build step:
 
 ```bash
-docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.3.10
+docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.3.11
 ```
 
 | Tag | Meaning |
 |---|---|
-| `0.3.10` | An exact release. **Prefer this in deployments.** |
+| `0.3.11` | An exact release. **Prefer this in deployments.** |
 | `0.3` | Latest patch of the 0.3 line. |
 | `latest` | Latest release, whatever it currently is. |
 
-The image tag carries **no `v` prefix**, unlike the Go module version: `@v0.3.10` for `add-package`, `:0.3.10` for `docker pull`.
+The image tag carries **no `v` prefix**, unlike the Go module version: `@v0.3.11` for `add-package`, `:0.3.11` for `docker pull`.
 
 See [docker.md](docker.md) for mounting rule files and blacklists, Docker Compose, and hot reload inside a container.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,7 +41,7 @@ A representative response:
   "dns_blacklist_hits":            0,
   "rate_limiter_requests":         27004,
   "rate_limiter_blocked_requests": 23640,
-  "version":                       "v0.3.10"
+  "version":                       "v0.3.11"
 }
 ```
 

--- a/handler.go
+++ b/handler.go
@@ -300,6 +300,19 @@ func (m *Middleware) handlePhase(w http.ResponseWriter, r *http.Request, phase i
 	)
 
 	if phase == 1 {
+		// A whitelisted peer is exempt from the IP-reputation controls: the IP
+		// blacklist, the country allow/block lists and the ASN filter. It is NOT
+		// exempt from the DNS blacklist (which is about the requested host, not
+		// who is asking), the rate limiter, or the rule engine -- those still
+		// apply. See issue #137: the case this solves is a private address being
+		// blocked by whitelist_countries because it has no geolocation, and the
+		// answer to that is not to switch the WAF off for it.
+		ipExempt := m.isIPWhitelisted(r.RemoteAddr)
+		if ipExempt {
+			m.logger.Debug("Peer address is whitelisted; skipping IP reputation checks",
+				zap.String("remote_addr", r.RemoteAddr))
+		}
+
 		// IP blacklisting - the highest priority
 		m.logger.Debug("Checking for IP blacklisting", zap.String("remote_addr", r.RemoteAddr)) // Added log for checking before to isIPBlacklisted call
 		// Check the peer address FIRST and unconditionally.
@@ -322,6 +335,10 @@ func (m *Middleware) handlePhase(w http.ResponseWriter, r *http.Request, phase i
 					candidates = append(candidates, hop)
 				}
 			}
+		}
+
+		if ipExempt {
+			candidates = nil
 		}
 
 		for _, candidate := range candidates {
@@ -372,7 +389,7 @@ func (m *Middleware) handlePhase(w http.ResponseWriter, r *http.Request, phase i
 		}
 
 		// Whitelisting
-		if m.CountryWhitelist.Enabled {
+		if m.CountryWhitelist.Enabled && !ipExempt {
 			m.logger.Debug("Starting country whitelisting phase")
 			clientIP := getClientIP(r)
 			allowed, err := m.isCountryInList(clientIP, m.CountryWhitelist.CountryList, m.CountryWhitelist.geoIP)
@@ -405,7 +422,7 @@ func (m *Middleware) handlePhase(w http.ResponseWriter, r *http.Request, phase i
 		}
 
 		// ASN Blocking
-		if m.BlockASNs.Enabled {
+		if m.BlockASNs.Enabled && !ipExempt {
 			m.logger.Debug("Starting ASN blocking phase")
 			clientIP := getClientIP(r)
 			blocked, err := m.geoIPHandler.IsASNInList(clientIP, m.BlockASNs.BlockedASNs, m.BlockASNs.geoIP)
@@ -440,7 +457,7 @@ func (m *Middleware) handlePhase(w http.ResponseWriter, r *http.Request, phase i
 		}
 
 		// Blacklisting
-		if m.CountryBlacklist.Enabled {
+		if m.CountryBlacklist.Enabled && !ipExempt {
 			m.logger.Debug("Starting country blacklisting phase")
 			clientIP := getClientIP(r)
 			blocked, err := m.isCountryInList(clientIP, m.CountryBlacklist.CountryList, m.CountryBlacklist.geoIP)

--- a/ipwhitelist.go
+++ b/ipwhitelist.go
@@ -1,0 +1,94 @@
+package caddywaf
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+
+	"github.com/phemmer/go-iptrie"
+	"go.uber.org/zap"
+)
+
+// PrivateRangesToken is the shorthand accepted by the whitelist_ip directive.
+// It expands to privateRanges below, matching the set Caddy uses for its own
+// private_ranges placeholder, so an operator does not have to remember two
+// different definitions of "private".
+const PrivateRangesToken = "private_ranges"
+
+// privateRanges mirrors Caddy's private_ranges. Deliberately identical rather
+// than "improved": a WAF and the server in front of it disagreeing about which
+// addresses are private is the kind of subtle mismatch that produces a bypass.
+var privateRanges = []string{
+	"192.168.0.0/16",
+	"172.16.0.0/12",
+	"10.0.0.0/8",
+	"127.0.0.1/8",
+	"fd00::/8",
+	"::1",
+}
+
+// buildIPWhitelist compiles the configured entries into a prefix trie.
+//
+// Entries may be a bare IP, a CIDR range, or PrivateRangesToken. An
+// unparseable entry is an error rather than a warning: a whitelist that
+// silently drops an entry fails in the dangerous direction for the operator
+// (their address is not exempt) and there is no reason to guess.
+func buildIPWhitelist(entries []string) (*iptrie.Trie, []string, error) {
+	trie := iptrie.NewTrie()
+	var expanded []string
+
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if strings.EqualFold(entry, PrivateRangesToken) {
+			expanded = append(expanded, privateRanges...)
+			continue
+		}
+		expanded = append(expanded, entry)
+	}
+
+	for _, entry := range expanded {
+		cidr := entry
+		if !strings.Contains(cidr, "/") {
+			cidr = appendCIDR(cidr)
+		}
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid whitelist_ip entry %q: %w", entry, err)
+		}
+		trie.Insert(prefix, nil)
+	}
+
+	return trie, expanded, nil
+}
+
+// isIPWhitelisted reports whether addr is exempt from the IP-reputation checks.
+//
+// It takes ONLY the peer address, never X-Forwarded-For, and that asymmetry
+// with the blacklist is deliberate. For blocking, consulting extra addresses
+// can only ever block more, so the forwarded chain is fair game. For allowing,
+// the opposite holds: honouring a client-supplied header would let anyone send
+// "X-Forwarded-For: 10.0.0.1" and exempt themselves from the blacklist, the
+// country filter and the ASN filter in one move. The peer address is the only
+// value a client cannot forge, so it is the only one trusted here.
+func (m *Middleware) isIPWhitelisted(remoteAddr string) bool {
+	m.mu.RLock()
+	trie := m.ipWhitelist
+	m.mu.RUnlock()
+
+	if trie == nil {
+		return false
+	}
+
+	ip := extractIP(remoteAddr)
+	parsed, err := netip.ParseAddr(ip)
+	if err != nil {
+		m.logger.Debug("Failed to parse peer address for whitelist check",
+			zap.String("ip", ip), zap.Error(err))
+		return false
+	}
+
+	return trie.Contains(parsed)
+}

--- a/ipwhitelist_test.go
+++ b/ipwhitelist_test.go
@@ -1,0 +1,193 @@
+package caddywaf
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/phemmer/go-iptrie"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestBuildIPWhitelist(t *testing.T) {
+	t.Run("private_ranges expands to Caddy's set", func(t *testing.T) {
+		_, expanded, err := buildIPWhitelist([]string{PrivateRangesToken})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, privateRanges, expanded)
+	})
+
+	t.Run("accepts bare IPs, CIDRs and the token together", func(t *testing.T) {
+		trie, _, err := buildIPWhitelist([]string{"private_ranges", "203.0.113.4", "198.51.100.0/24", "2001:db8::1"})
+		require.NoError(t, err)
+		m := &Middleware{logger: zap.NewNop(), ipWhitelist: trie}
+		for _, tc := range []struct {
+			addr    string
+			exempt  bool
+			comment string
+		}{
+			{"10.1.2.3:5000", true, "inside 10/8 via private_ranges"},
+			{"192.168.1.10:443", true, "inside 192.168/16"},
+			{"127.0.0.1:8080", true, "loopback"},
+			{"[::1]:443", true, "IPv6 loopback"},
+			{"203.0.113.4:1", true, "bare IP"},
+			{"198.51.100.77:1", true, "inside the /24"},
+			{"[2001:db8::1]:443", true, "bare IPv6"},
+			{"8.8.8.8:53", false, "public, not listed"},
+			{"198.51.101.1:1", false, "just outside the /24"},
+		} {
+			assert.Equalf(t, tc.exempt, m.isIPWhitelisted(tc.addr), "%s (%s)", tc.addr, tc.comment)
+		}
+	})
+
+	t.Run("an unparseable entry fails rather than being skipped", func(t *testing.T) {
+		_, _, err := buildIPWhitelist([]string{"203.0.113.0/33"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid whitelist_ip entry")
+
+		_, _, err = buildIPWhitelist([]string{"not-an-ip"})
+		require.Error(t, err)
+	})
+
+	t.Run("no whitelist configured exempts nobody", func(t *testing.T) {
+		m := &Middleware{logger: zap.NewNop()}
+		assert.False(t, m.isIPWhitelisted("10.0.0.1:1"))
+	})
+}
+
+// TestWhitelistIgnoresForwardedHeaders is the security property of this feature.
+//
+// The blacklist checks the peer address AND the forwarded chain, because
+// checking more can only block more. The whitelist must do the opposite: if it
+// honoured X-Forwarded-For, anyone could send "X-Forwarded-For: 10.0.0.1" and
+// exempt themselves from the blacklist, the country filter and the ASN filter
+// in a single header.
+func TestWhitelistIgnoresForwardedHeaders(t *testing.T) {
+	trie, _, err := buildIPWhitelist([]string{PrivateRangesToken})
+	require.NoError(t, err)
+	m := &Middleware{logger: zap.NewNop(), ipWhitelist: trie}
+
+	assert.True(t, m.isIPWhitelisted("10.0.0.5:1234"), "a genuinely private peer is exempt")
+
+	// Same helper, but the private address is only claimed in a header.
+	r := httptest.NewRequest(http.MethodGet, testURL, nil)
+	r.RemoteAddr = "203.0.113.9:1234"
+	r.Header.Set("X-Forwarded-For", "10.0.0.5")
+	assert.False(t, m.isIPWhitelisted(r.RemoteAddr),
+		"a forged X-Forwarded-For must never grant an exemption")
+}
+
+func TestWhitelistEndToEnd(t *testing.T) {
+	logger := zap.NewNop()
+
+	blFile, err := os.CreateTemp(t.TempDir(), "ipbl*.txt")
+	require.NoError(t, err)
+	_, err = blFile.WriteString("10.0.0.5\n203.0.113.9\n")
+	require.NoError(t, err)
+	require.NoError(t, blFile.Close())
+
+	newMW := func(t *testing.T, whitelist []string) *Middleware {
+		t.Helper()
+		m := &Middleware{
+			logger:           logger,
+			blacklistLoader:  NewBlacklistLoader(logger),
+			AnomalyThreshold: 5,
+			ruleCache:        NewRuleCache(),
+			ipBlacklist:      iptrie.NewTrie(),
+			dnsBlacklist:     map[string]struct{}{},
+			ruleHitsByPhase:  map[int]int64{},
+			// A phase-1 rule that must still apply to whitelisted clients.
+			Rules: map[int][]Rule{1: {{
+				ID: "attack", Pattern: "attackpayload", Targets: []string{"URI"},
+				Phase: 1, Score: 10, Action: "block", regex: regexp.MustCompile("attackpayload"),
+			}}},
+			requestValueExtractor: NewRequestValueExtractor(logger, false, 0),
+		}
+		require.NoError(t, m.loadIPBlacklist(blFile.Name(), m.ipBlacklist))
+		if whitelist != nil {
+			trie, _, err := buildIPWhitelist(whitelist)
+			require.NoError(t, err)
+			m.ipWhitelist = trie
+		}
+		return m
+	}
+
+	probe := func(t *testing.T, m *Middleware, remote, target string, header map[string]string) (int, bool) {
+		t.Helper()
+		reached := false
+		next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+			reached = true
+			_, err := w.Write([]byte("UPSTREAM"))
+			return err
+		})
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		req.RemoteAddr = remote
+		for k, v := range header {
+			req.Header.Set(k, v)
+		}
+		w := httptest.NewRecorder()
+		require.NoError(t, m.ServeHTTP(w, req, next))
+		return w.Code, reached
+	}
+
+	t.Run("without a whitelist the blacklisted private IP is blocked", func(t *testing.T) {
+		m := newMW(t, nil)
+		code, reached := probe(t, m, "10.0.0.5:1234", testURL+"/", nil)
+		assert.Equal(t, http.StatusForbidden, code)
+		assert.False(t, reached)
+	})
+
+	t.Run("whitelisting private_ranges takes precedence over the IP blacklist", func(t *testing.T) {
+		m := newMW(t, []string{PrivateRangesToken})
+		code, reached := probe(t, m, "10.0.0.5:1234", testURL+"/", nil)
+		assert.Equal(t, http.StatusOK, code)
+		assert.True(t, reached, "the whitelisted peer must reach the upstream")
+	})
+
+	t.Run("a whitelisted peer is still subject to the rule engine", func(t *testing.T) {
+		m := newMW(t, []string{PrivateRangesToken})
+		code, reached := probe(t, m, "10.0.0.5:1234", testURL+"/?q=attackpayload", nil)
+		assert.Equal(t, http.StatusForbidden, code,
+			"the exemption covers IP reputation, not the rules")
+		assert.False(t, reached)
+	})
+
+	t.Run("a public peer cannot claim an exemption with a header", func(t *testing.T) {
+		m := newMW(t, []string{PrivateRangesToken})
+		code, reached := probe(t, m, "203.0.113.9:1234", testURL+"/",
+			map[string]string{"X-Forwarded-For": "10.0.0.1"})
+		assert.Equal(t, http.StatusForbidden, code,
+			"203.0.113.9 is blacklisted and must stay blocked despite the header")
+		assert.False(t, reached)
+	})
+}
+
+func TestParseWhitelistIPDirective(t *testing.T) {
+	for _, tc := range []struct {
+		name, cfg string
+		wantErr   bool
+		want      []string
+	}{
+		{"token plus entries", "waf {\n rule_file rules.json\n whitelist_ip private_ranges 203.0.113.4\n}", false,
+			[]string{"private_ranges", "203.0.113.4"}},
+		{"repeatable", "waf {\n rule_file rules.json\n whitelist_ip 10.0.0.0/8\n whitelist_ip 203.0.113.4\n}", false,
+			[]string{"10.0.0.0/8", "203.0.113.4"}},
+		{"no arguments is an error", "waf {\n rule_file rules.json\n whitelist_ip\n}", true, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Middleware{}
+			err := NewConfigLoader(zap.NewNop()).UnmarshalCaddyfile(caddyfile.NewTestDispenser(tc.cfg), m)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, m.IPWhitelist)
+		})
+	}
+}

--- a/types.go
+++ b/types.go
@@ -114,8 +114,12 @@ type WAFState struct {
 type Middleware struct {
 	mu sync.RWMutex
 
-	RuleFiles        []string            `json:"rule_files"`
-	IPBlacklistFile  string              `json:"ip_blacklist_file"`
+	RuleFiles       []string `json:"rule_files"`
+	IPBlacklistFile string   `json:"ip_blacklist_file"`
+	// IPWhitelist holds entries exempt from the IP-reputation checks: bare IPs,
+	// CIDR ranges, or the token "private_ranges". See whitelist_ip in
+	// docs/configuration.md.
+	IPWhitelist      []string            `json:"ip_whitelist,omitempty"`
 	DNSBlacklistFile string              `json:"dns_blacklist_file"`
 	AnomalyThreshold int                 `json:"anomaly_threshold"`
 	CountryBlacklist CountryAccessFilter `json:"country_blacklist"`
@@ -123,6 +127,7 @@ type Middleware struct {
 	BlockASNs        ASNAccessFilter     `json:"block_asns"`
 	Rules            map[int][]Rule      `json:"-"`
 	ipBlacklist      *iptrie.Trie        `json:"-"`
+	ipWhitelist      *iptrie.Trie        `json:"-"`
 	dnsBlacklist     map[string]struct{} `json:"-"` // Changed to map[string]struct{}
 	logger           *zap.Logger
 	LogSeverity      string `json:"log_severity,omitempty"`


### PR DESCRIPTION
Closes #137.

## The problem, in @nozonyan's words

`whitelist_countries` blocks anything it cannot geolocate — which includes every address on your own LAN. So turning it on locks you out of your own service from inside the network. The available workarounds were both bad:

- `geoip_fail_open`, which also admits **every unresolvable public address**;
- two site blocks with separate rule sets — and, as the issue says, *"it can also result in my service being exposed temporarily or permanently if I forget to switch the waf rules back."*

That last part is the real cost: the workaround is a safety hazard.

## The directive

```caddyfile
waf {
    rule_file rules.json

    whitelist_ip private_ranges
    whitelist_ip 203.0.113.4 198.51.100.0/24
}
```

Bare IPs, CIDR ranges, or the token `private_ranges`. Repeatable. An entry that does not parse **fails startup** rather than being skipped with a warning — a whitelist that silently drops an entry leaves the operator believing an address is exempt when it is not.

`private_ranges` expands to exactly Caddy's own set: `192.168.0.0/16`, `172.16.0.0/12`, `10.0.0.0/8`, `127.0.0.1/8`, `fd00::/8`, `::1`. Identical rather than "improved" — a WAF and the server in front of it disagreeing about which addresses are private is how bypasses get built.

## Scope of the exemption

| Check | Exempt? |
|---|---|
| IP blacklist (incl. Tor exit nodes fed into it) | **yes** |
| `whitelist_countries` / `block_countries` | **yes** |
| `block_asns` | **yes** |
| DNS blacklist | no — judges the requested host, not the client |
| Rate limiting | no |
| Regex rules, all four phases | no |

This is the design, not a gap. The issue asks for precedence over "the explicit ip_blacklist and asn/geo blocks" — the reputation controls. Exempting an address from geolocation is the fix; stopping inspection of its requests is not, and a whitelisted device that later gets compromised should not get a free pass.

## Two security properties, both tested

**1. The whitelist reads the peer address only — never `X-Forwarded-For`.**

Deliberately the opposite of the blacklist, which checks the peer *and* every forwarded hop:

- **Blocking**: consulting extra addresses can only block more. Safe.
- **Allowing**: honouring a client-supplied header would let anyone send `X-Forwarded-For: 10.0.0.1` and exempt themselves from the blacklist, the country filter and the ASN filter **in one header** — reintroducing exactly the bypass fixed in v0.3.8, from the other direction.

`TestWhitelistIgnoresForwardedHeaders` pins this, and an end-to-end case confirms a blacklisted public peer stays blocked while claiming a private address in the header.

**2. `private_ranges` is only safe when caddy-waf is the edge.**

Because the check is on the peer address, running behind another proxy makes the peer *that proxy* — typically loopback or private — which would exempt **every** request passing through it and silently disable three controls.

Provision logs a warning when `private_ranges` is whitelisted, and `docs/configuration.md` carries a WARNING block. I would rather ship the footgun documented and announced than not ship the feature.

## Tests

`ipwhitelist_test.go`: `private_ranges` expansion, mixed entry types, IPv4/IPv6/CIDR/with-and-without-port matching, invalid entry rejected at build time, no-whitelist-exempts-nobody, the forged-header property, Caddyfile parsing (including the zero-argument error), and four end-to-end cases through `ServeHTTP` — including *"a whitelisted peer is still subject to the rule engine"*.

Full suite green under `-race`. Docs build clean, anchors validated.

## Docs

- `docs/configuration.md`: directive row, updated Phase 1 order and precedence summary, and a dedicated **IP whitelist** section covering scope, the peer-address rationale, and the proxy warning.
- `docs/geoblocking.md`: a TIP where the problem is actually felt — enabling `whitelist_countries` can lock you out from your own LAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)