### PR TITLE
fix: response-target rule in an early phase panics the whole request (#144)

### DIFF
--- a/request.go
+++ b/request.go
@@ -133,7 +133,7 @@ func (rve *RequestValueExtractor) extractSingleValue(target string, r *http.Requ
 		},
 		TargetBody:            func() (string, error) { return rve.extractBody(r, target) },                                     // Separate body extraction
 		TargetHeaders:         func() (string, error) { return rve.extractAllHeaders(r.Header, "Request headers", target) },     // Helper for headers
-		TargetResponseHeaders: func() (string, error) { return rve.extractAllHeaders(w.Header(), "Response headers", target) },  // Helper for response headers
+		TargetResponseHeaders: func() (string, error) { return rve.extractResponseHeaders(w, target) },                          // nil-safe; see issue #144
 		TargetResponseBody:    func() (string, error) { return rve.extractResponseBody(w, target) },                             // Helper for response body
 		TargetFileName:        func() (string, error) { return rve.extractFileName(r, target) },                                 // Helper for filename
 		TargetFileMIMEType:    func() (string, error) { return rve.extractFileMIMEType(r, target) },                             // Helper for mime type
@@ -157,6 +157,9 @@ func (rve *RequestValueExtractor) extractSingleValue(target string, r *http.Requ
 			return "", err
 		}
 	} else if strings.HasPrefix(target, TargetResponseHeadersPrefix) {
+		if w == nil {
+			return "", fmt.Errorf("response headers not accessible outside Phase 3/4 for target: %s", target)
+		}
 		unredactedValue, err = rve.extractDynamicResponseHeader(w.Header(), strings.TrimPrefix(target, TargetResponseHeadersPrefix), target)
 		if err != nil {
 			return "", err
@@ -264,6 +267,18 @@ func (rve *RequestValueExtractor) extractAllHeaders(header http.Header, logMessa
 		headers = append(headers, fmt.Sprintf("%s: %s", name, strings.Join(values, ",")))
 	}
 	return strings.Join(headers, "; "), nil
+}
+
+// extractResponseHeaders returns the full response header set. Response targets
+// are only populated in Phase 3/4; when a rule file places RESPONSE_HEADERS in
+// an earlier phase (several OWASP CRS rules do, e.g. 950010), handlePhase passes
+// a nil writer, so this must degrade to an error rather than dereference nil.
+// See issue #144.
+func (rve *RequestValueExtractor) extractResponseHeaders(w http.ResponseWriter, target string) (string, error) {
+	if w == nil {
+		return "", fmt.Errorf("response headers not accessible outside Phase 3/4 for target: %s", target)
+	}
+	return rve.extractAllHeaders(w.Header(), "Response headers", target)
 }
 
 // Helper function to extract response body (for phase 4)

--- a/response_target_crash_test.go
+++ b/response_target_crash_test.go
@@ -1,0 +1,75 @@
+package caddywaf
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/phemmer/go-iptrie"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// newCrashProbeMiddleware builds a minimal, provisioned-enough Middleware that
+// carries a single rule, so a test can drive a target through the full
+// ServeHTTP path.
+func newCrashProbeMiddleware(t *testing.T, rule Rule) *Middleware {
+	t.Helper()
+	logger := zap.NewNop()
+	return &Middleware{
+		logger:                logger,
+		blacklistLoader:       NewBlacklistLoader(logger),
+		AnomalyThreshold:      1000, // score only, never block: we want the request to reach next
+		ruleCache:             NewRuleCache(),
+		ipBlacklist:           iptrie.NewTrie(),
+		dnsBlacklist:          map[string]struct{}{},
+		ruleHitsByPhase:       map[int]int64{},
+		Rules:                 map[int][]Rule{rule.Phase: {rule}},
+		requestValueExtractor: NewRequestValueExtractor(logger, false, 0),
+	}
+}
+
+// TestResponseHeaderTargetInEarlyPhaseDoesNotPanic pins issue #144.
+//
+// handlePhase passes a nil http.ResponseWriter to value extraction in Phases 1
+// and 2, because the response does not exist yet. A rule that targets
+// RESPONSE_HEADERS in one of those phases (several OWASP CRS rules do, e.g.
+// 950010, which lists RESPONSE_HEADERS in phase 2) therefore reached
+// w.Header() on a nil writer and panicked. ServeHTTP's recovery turned that
+// into a 500 on *every* request, taking the whole site offline behind the WAF.
+//
+// The extractor must degrade to a skipped target, not a nil dereference, so the
+// request passes through untouched.
+func TestResponseHeaderTargetInEarlyPhaseDoesNotPanic(t *testing.T) {
+	for _, target := range []string{"RESPONSE_HEADERS", "RESPONSE_HEADERS:Content-Encoding"} {
+		t.Run(target, func(t *testing.T) {
+			m := newCrashProbeMiddleware(t, Rule{
+				ID: "950010", Phase: 2, Pattern: "gzip",
+				Targets: []string{target},
+				Score:   1, Action: "log", regex: regexp.MustCompile("gzip"),
+			})
+
+			next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+				w.Header().Set("Content-Encoding", "gzip")
+				_, err := w.Write([]byte("ok"))
+				return err
+			})
+
+			req := httptest.NewRequest(http.MethodGet, testURL+"/", nil)
+			req.RemoteAddr = "203.0.113.7:1234"
+			rec := httptest.NewRecorder()
+
+			err := m.ServeHTTP(rec, req, next)
+			require.NoError(t, err)
+
+			// A recovered panic surfaces as a 500 with a plain-text body; the
+			// healthy path returns the upstream's 200 "ok".
+			assert.Equal(t, http.StatusOK, rec.Code,
+				"a response-target rule in an early phase must not 500 the request")
+			assert.Equal(t, "ok", rec.Body.String())
+		})
+	}
+}


### PR DESCRIPTION
## What

Fixes #144. A nil-pointer panic took the whole site offline (HTTP 500 on **every** request) when a rule targeted the response headers in an early phase.

## Root cause

`handlePhase` passes a nil `http.ResponseWriter` to value extraction in phases 1 and 2, because the response does not exist yet. The `RESPONSE_HEADERS` extractor and the dynamic `RESPONSE_HEADERS:<name>` branch both called `w.Header()` unconditionally, so a rule that placed a response target in phase 1/2 dereferenced nil. Several OWASP CRS rules do exactly this — the reporter hit `950010`, which lists `RESPONSE_HEADERS` in phase 2. `ServeHTTP`'s panic recovery converted it into a 500, so the site was down behind the WAF.

`extractResponseBody` already guarded `w == nil`; the two response-header paths did not.

## Fix

- New nil-safe `extractResponseHeaders` helper, used by the `RESPONSE_HEADERS` extractor.
- Explicit `w == nil` guard on the dynamic `RESPONSE_HEADERS:` branch.

Both mirror the existing `extractResponseBody` pattern: an out-of-phase response target degrades to a **skipped target** (extraction returns an error, `handlePhase` `continue`s) instead of crashing. No behavior change for rules that use response targets in phases 3/4, where they belong.

## Test

`response_target_crash_test.go` drives both `RESPONSE_HEADERS` and `RESPONSE_HEADERS:<name>` in a phase-2 rule end-to-end through `ServeHTTP`. It **fails on the pre-fix code** (recovered panic → 500 / "Internal Server Error") and **passes on the fix** (200, upstream body passes through untouched). Full package suite is green; `gofumpt`/`go vet`/`go build` clean.

Reported on OPNsense (caddy v2.11.4) with OWASP rules — thanks to the reporter for the clean stack trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)