### PR TITLE
test: make TestTorConfig_Provision hermetic (no external CDN fetch)

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -10,7 +10,6 @@ const (
 	googleBRIP = "128.201.228.12"
 	googleRUIP = "74.125.131.94"
 	testURL    = "http://example.com"
-	torListURL = "https://cdn.nws.neurodyne.pro/nws-cdn-ut8hw561/waf/torbulkexitlist" // custom TOR list URL for testing
 )
 
 var customResponse = map[int]CustomBlockResponse{

--- a/tor_test.go
+++ b/tor_test.go
@@ -13,6 +13,15 @@ import (
 )
 
 func TestTorConfig_Provision(t *testing.T) {
+	// Serve a fake exit-node list locally so provisioning never reaches an
+	// external host. This test used to point CustomTORExitNodeURL at a real CDN
+	// (torListURL), so a transient TLS/network hiccup on the runner became a red
+	// CI run unrelated to any code change -- exactly what bit PR #146.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("1.1.1.1\n2.2.2.2\n3.3.3.3\n"))
+	}))
+	defer ts.Close()
+
 	// Create temp file for testing
 	tmpFile, err := os.CreateTemp("", "tor_blacklist_*.txt")
 	if err != nil {
@@ -42,7 +51,7 @@ func TestTorConfig_Provision(t *testing.T) {
 			name: "enabled config",
 			config: TorConfig{
 				Enabled:              true,
-				CustomTORExitNodeURL: torListURL,
+				CustomTORExitNodeURL: ts.URL,
 				TORIPBlacklistFile:   tmpFile.Name(),
 				UpdateInterval:       "5m",
 				logger:               logger,


### PR DESCRIPTION
## What

Removes the last network dependency from the test suite. `TestTorConfig_Provision/enabled_config` fetched a live external CDN (`torListURL`) during `Provision`, so a transient TLS/network hiccup on the CI runner produced a red run unrelated to any code change.

This is the follow-up flagged during #146, where exactly this test flaked (TLS handshake timeout) and only cleared on a bare re-run.

## Fix

- `TestTorConfig_Provision` now serves the exit-node list from a local `httptest.Server`, the same pattern `TestTorConfig_updateTorExitNodes` already uses.
- Dropped the now-unused `torListURL` const (the external CDN URL) from `common_test.go`.

## Result

The `enabled_config` subtest goes from a 10.5s network timeout on failure to **0.00s**, and the suite no longer depends on any third-party host. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)