### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.4.1] - 2026-08-21
+
+### Fixed
+- **A response-target rule in an early phase no longer panics the request.** A rule listing `RESPONSE_HEADERS` (or `RESPONSE_HEADERS:<name>`) in phase 1 or 2 — as several OWASP CRS rules do, e.g. `950010` — reached `w.Header()` on the nil `http.ResponseWriter` that `handlePhase` passes before the response exists. The panic was recovered into an HTTP 500, so **every** request behind the WAF failed. Response-header extraction is now nil-safe (mirroring the existing response-body guard): an out-of-phase response target degrades to a skipped target instead of crashing. Reported on OPNsense with OWASP rules ([#144](https://github.com/fabriziosalmi/caddy-waf/issues/144), [#146](https://github.com/fabriziosalmi/caddy-waf/pull/146)).
+
+### Changed
+- Bumped version constant `wafVersion` to `v0.4.1`.
+
+### Internal
+- `TestTorConfig_Provision` is now hermetic — it serves the Tor exit-node list from a local `httptest.Server` instead of a live external CDN, removing the last third-party network dependency from CI ([#147](https://github.com/fabriziosalmi/caddy-waf/pull/147)).
+
 ## [v0.4.0] - 2026-08-18
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Web Application Firewall middleware for the [Caddy](https://caddyserver.com/) 
 
 - **Module ID**: `http.handlers.waf` — [registered in Caddy's package registry](https://caddyserver.com/docs/modules/http.handlers.waf), so the module is selectable on the [download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf)
 - **Go module path**: `github.com/fabriziosalmi/caddy-waf`
-- **Current version**: `v0.4.0` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
+- **Current version**: `v0.4.1` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
 - **License**: AGPL-3.0 — note this is a copyleft licence; check it suits your deployment before integrating
 
 ---
@@ -67,7 +67,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version  {"version":"v0.4.0"}
+INFO  WAF middleware version  {"version":"v0.4.1"}
 INFO  Rate limit configuration  {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded     {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}
@@ -142,11 +142,11 @@ It is also selectable on [caddyserver.com/download](https://caddyserver.com/down
 Images are published to GitHub Container Registry on every release tag, for `linux/amd64` and `linux/arm64`:
 
 ```bash
-docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.0
-docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.0
+docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.1
+docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.1
 ```
 
-Tags are `0.4.0`, `0.4` and `latest` — note there is **no `v` prefix**, unlike the Go module version. Pin an exact version in anything you deploy. See [`docs/docker.md`](docs/docker.md) for volumes, Compose, and hot reload.
+Tags are `0.4.1`, `0.4` and `latest` — note there is **no `v` prefix**, unlike the Go module version. Pin an exact version in anything you deploy. See [`docs/docker.md`](docs/docker.md) for volumes, Compose, and hot reload.
 
 ---
 

--- a/caddywaf.go
+++ b/caddywaf.go
@@ -49,7 +49,7 @@ var (
 )
 
 // Add or update the version constant as needed
-const wafVersion = "v0.4.0" // update this value to the new release version when tagging
+const wafVersion = "v0.4.1" // update this value to the new release version when tagging
 
 // ==================== Initialization and Setup ====================
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     # security fixes, and `latest` leaves no way to name the image you tested
     # against. Swap for `build: .` to run your local checkout instead -- since
     # v0.4.0 that actually compiles the working tree.
-    image: ghcr.io/fabriziosalmi/caddy-waf:0.4.0
+    image: ghcr.io/fabriziosalmi/caddy-waf:0.4.1
     # build: .
     ports:
       - "8080:8080"

--- a/docs/add-package-guide.md
+++ b/docs/add-package-guide.md
@@ -54,7 +54,7 @@ caddy list-modules | grep waf
 ## Pin a version
 
 ```bash
-caddy add-package github.com/fabriziosalmi/caddy-waf@v0.4.0
+caddy add-package github.com/fabriziosalmi/caddy-waf@v0.4.1
 ```
 
 Any tag from the [Releases](https://github.com/fabriziosalmi/caddy-waf/releases)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,16 +7,16 @@ The repository ships a [`Dockerfile`](https://github.com/fabriziosalmi/caddy-waf
 Images are published to GitHub Container Registry on every release tag, for `linux/amd64` and `linux/arm64`:
 
 ```bash
-docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.0
+docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.1
 ```
 
 | Tag | Meaning |
 |---|---|
-| `0.4.0` | An exact release. **Prefer this.** |
+| `0.4.1` | An exact release. **Prefer this.** |
 | `0.4` | Latest patch of the 0.3 line. |
 | `latest` | Latest release, whatever it currently is. |
 
-Note the image tag carries **no `v` prefix**, unlike the Go module version: `caddy add-package …@v0.4.0` but `docker pull …:0.4.0`.
+Note the image tag carries **no `v` prefix**, unlike the Go module version: `caddy add-package …@v0.4.1` but `docker pull …:0.4.1`.
 
 Pin an exact version in anything you deploy. `latest` gives you no way to name the image you tested against, which matters when a release fixes a security defect — see [Security → Advisories](https://github.com/fabriziosalmi/caddy-waf/security/advisories).
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -13,7 +13,7 @@ docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.1
 | Tag | Meaning |
 |---|---|
 | `0.4.1` | An exact release. **Prefer this.** |
-| `0.4` | Latest patch of the 0.3 line. |
+| `0.4` | Latest patch of the 0.4 line. |
 | `latest` | Latest release, whatever it currently is. |
 
 Note the image tag carries **no `v` prefix**, unlike the Go module version: `caddy add-package …@v0.4.1` but `docker pull …:0.4.1`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ xcaddy build --with github.com/fabriziosalmi/caddy-waf
 Or run the published container image, which needs no Go toolchain:
 
 ```bash
-docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.0
+docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.1
 ```
 
 The module is also selectable on the [Caddy download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf), and `caddy add-package github.com/fabriziosalmi/caddy-waf` works for a one-off install — though Caddy's maintainers have proposed moving that command out of core, so do not build a deployment around it ([#138](https://github.com/fabriziosalmi/caddy-waf/issues/138)).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version          {"version":"v0.4.0"}
+INFO  WAF middleware version          {"version":"v0.4.1"}
 INFO  Rate limit configuration        {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded             {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}
@@ -82,7 +82,7 @@ The module is registered in Caddy's package registry, so an existing Caddy v2.7+
 caddy add-package github.com/fabriziosalmi/caddy-waf
 ```
 
-This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.4.0` if needed.
+This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.4.1` if needed.
 
 The module is also selectable on <https://caddyserver.com/download>.
 
@@ -93,16 +93,16 @@ See [add-package-guide.md](add-package-guide.md) for the full flow, removal, and
 Images are published to GitHub Container Registry on every release tag, for `linux/amd64` and `linux/arm64`. No Go toolchain, no build step:
 
 ```bash
-docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.0
+docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.1
 ```
 
 | Tag | Meaning |
 |---|---|
-| `0.4.0` | An exact release. **Prefer this in deployments.** |
+| `0.4.1` | An exact release. **Prefer this in deployments.** |
 | `0.4` | Latest patch of the 0.3 line. |
 | `latest` | Latest release, whatever it currently is. |
 
-The image tag carries **no `v` prefix**, unlike the Go module version: `@v0.4.0` for `add-package`, `:0.4.0` for `docker pull`.
+The image tag carries **no `v` prefix**, unlike the Go module version: `@v0.4.1` for `add-package`, `:0.4.1` for `docker pull`.
 
 See [docker.md](docker.md) for mounting rule files and blacklists, Docker Compose, and hot reload inside a container.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -99,7 +99,7 @@ docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.1
 | Tag | Meaning |
 |---|---|
 | `0.4.1` | An exact release. **Prefer this in deployments.** |
-| `0.4` | Latest patch of the 0.3 line. |
+| `0.4` | Latest patch of the 0.4 line. |
 | `latest` | Latest release, whatever it currently is. |
 
 The image tag carries **no `v` prefix**, unlike the Go module version: `@v0.4.1` for `add-package`, `:0.4.1` for `docker pull`.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,7 +41,7 @@ A representative response:
   "dns_blacklist_hits":            0,
   "rate_limiter_requests":         27004,
   "rate_limiter_blocked_requests": 23640,
-  "version":                       "v0.4.0"
+  "version":                       "v0.4.1"
 }
 ```
 


### PR DESCRIPTION
Release prep for **v0.4.1** — a patch over v0.4.0.

## What ships in v0.4.1
- **Fix #144** ([#146](https://github.com/fabriziosalmi/caddy-waf/pull/146)): a response-target rule (`RESPONSE_HEADERS`) in an early phase no longer panics the request into a site-wide HTTP 500. Response-header extraction is now nil-safe.
- **Internal** ([#147](https://github.com/fabriziosalmi/caddy-waf/pull/147)): `TestTorConfig_Provision` is hermetic — CI no longer depends on an external CDN.

## This PR
- Bumps `wafVersion` → `v0.4.1`.
- Adds the `v0.4.1` CHANGELOG entry.
- Updates current-version / image-tag references across README and docs. ghcr tags carry **no `v` prefix** (`:0.4.1`); the Go module keeps `@v0.4.1`. Historical `v0.4.0` references (changelog history, "before v0.4.0" prose) are intentionally left intact.

## After merge
Tagging `v0.4.1` on the merge commit triggers `release.yml` (multi-arch binaries + GitHub Release) and `docker.yml` (publishes `:0.4.1`, `:0.4`, `:latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)