### PR TITLE
fix: hot-reload watcher misses atomic file renames

### DIFF
--- a/blacklist.go
+++ b/blacklist.go
@@ -67,11 +67,6 @@ func (bl *BlacklistLoader) LoadDNSBlacklistFromFile(path string, dnsBlacklist ma
 func (m *Middleware) isIPBlacklisted(addr string) bool {
 	ip := extractIP(addr)
 
-	if m.ipBlacklist == nil {
-		m.logger.Debug("IP blacklist not initialized, skipping check")
-		return false
-	}
-
 	parsedIP, err := netip.ParseAddr(ip)
 	if err != nil {
 		m.logger.Debug("Failed to parse IP address for blacklist check", zap.String("ip", ip), zap.Error(err))
@@ -79,13 +74,17 @@ func (m *Middleware) isIPBlacklisted(addr string) bool {
 	}
 
 	// ReloadConfig swaps m.ipBlacklist under m.mu, so the read must be
-	// synchronised or the swap races with every in-flight request. Mirrors
-	// what isDNSBlacklisted already does for the DNS map.
+	// synchronised or the swap races with every in-flight request (the hot
+	// reload the file watcher triggers is exactly such a swap). Snapshot the
+	// trie under the lock and nil-check the snapshot -- the old unsynchronised
+	// m.ipBlacklist == nil probe above the lock was a data race. Mirrors what
+	// isDNSBlacklisted already does for the DNS map.
 	m.mu.RLock()
 	trie := m.ipBlacklist
 	m.mu.RUnlock()
 
 	if trie == nil {
+		m.logger.Debug("IP blacklist not initialized, skipping check")
 		return false
 	}
 

--- a/caddywaf.go
+++ b/caddywaf.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/netip"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -433,33 +434,57 @@ func (m *Middleware) startFileWatcher(filePaths []string) {
 			}
 			defer watcher.Close()
 
-			err = watcher.Add(file)
-			if err != nil {
-				m.logger.Error("Failed to watch file", zap.String("file", file), zap.Error(err))
+			// Watch the parent directory, not the file inode. An atomic update
+			// (write a temp file, then os.Rename it over the target -- the standard
+			// pattern for blocklist/rule refreshes) replaces the target's inode. A
+			// watch on the file itself only ever sees Rename/Remove on the now-dead
+			// old inode, never fires for the replacement, and is left permanently
+			// deaf. Watching the directory and filtering by basename survives the
+			// swap with no re-arming, because the directory inode is stable.
+			dir := filepath.Dir(file)
+			base := filepath.Base(file)
+			if err := watcher.Add(dir); err != nil {
+				m.logger.Error("Failed to watch directory", zap.String("dir", dir), zap.String("file", file), zap.Error(err))
 				return
 			}
 
 			for {
 				select {
-				case event := <-watcher.Events:
-					if event.Op&fsnotify.Write == fsnotify.Write {
-						m.logger.Info("Detected configuration change. Reloading...", zap.String("file", file))
-						if strings.Contains(file, "rule") {
-							if err := m.ReloadRules(); err != nil {
-								m.logger.Error("Failed to reload rules after change", zap.String("file", file), zap.Error(err))
-							} else {
-								m.logger.Info("Rules reloaded successfully", zap.String("file", file))
-							}
+				case event, ok := <-watcher.Events:
+					if !ok {
+						return
+					}
+					// Only react to events for the file we track, not its siblings
+					// (e.g. the temp file an atomic write leaves behind).
+					if filepath.Base(event.Name) != base {
+						continue
+					}
+					// A plain edit emits Write; an atomic rename-into-place emits
+					// Create (inotify IN_MOVED_TO) and sometimes Rename for the
+					// target name. Any of the three means the contents changed and we
+					// must reload. A bare Remove (deletion, no replacement) is ignored.
+					if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) == 0 {
+						continue
+					}
+					m.logger.Info("Detected configuration change. Reloading...",
+						zap.String("file", file), zap.String("op", event.Op.String()))
+					if strings.Contains(file, "rule") {
+						if err := m.ReloadRules(); err != nil {
+							m.logger.Error("Failed to reload rules after change", zap.String("file", file), zap.Error(err))
 						} else {
-							err := m.ReloadConfig()
-							if err != nil {
-								m.logger.Error("Failed to reload config after change", zap.Error(err))
-							} else {
-								m.logger.Info("Configuration reloaded successfully")
-							}
+							m.logger.Info("Rules reloaded successfully", zap.String("file", file))
+						}
+					} else {
+						if err := m.ReloadConfig(); err != nil {
+							m.logger.Error("Failed to reload config after change", zap.Error(err))
+						} else {
+							m.logger.Info("Configuration reloaded successfully")
 						}
 					}
-				case err := <-watcher.Errors:
+				case err, ok := <-watcher.Errors:
+					if !ok {
+						return
+					}
 					m.logger.Error("File watcher error", zap.Error(err))
 				}
 			}

--- a/caddywaf.go
+++ b/caddywaf.go
@@ -454,8 +454,10 @@ func (m *Middleware) startFileWatcher(filePaths []string) {
 					if !ok {
 						return
 					}
-					// Only react to events for the file we track, not its siblings
-					// (e.g. the temp file an atomic write leaves behind).
+					// Only react to events for the file we track, not its
+					// siblings -- e.g. the temp file an atomic write creates and
+					// then renames away during the swap, whose Create/Write/Rename
+					// events all carry a different basename.
 					if filepath.Base(event.Name) != base {
 						continue
 					}

--- a/file_watcher_test.go
+++ b/file_watcher_test.go
@@ -1,0 +1,74 @@
+package caddywaf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/phemmer/go-iptrie"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// writeAtomic performs the standard atomic-update dance: write a temp file in
+// the same directory, then os.Rename it over the target. The rename replaces
+// the target's inode, which is precisely what a file-inode watch cannot follow.
+func writeAtomic(t *testing.T, dir, target, content string) {
+	t.Helper()
+	tmp := filepath.Join(dir, ".tmp-"+filepath.Base(target))
+	require.NoError(t, os.WriteFile(tmp, []byte(content), 0o644))
+	require.NoError(t, os.Rename(tmp, target))
+}
+
+// TestFileWatcherReloadsOnAtomicRename pins the hot-reload path against atomic
+// file updates.
+//
+// startFileWatcher used to call watcher.Add on the file path and react only to
+// fsnotify.Write. An atomic update (write temp + os.Rename over the target)
+// swaps the file's inode: fsnotify fires Rename/Remove on the old, now-dead
+// inode, no Write ever arrives, and the watch is left permanently deaf. So a
+// blocklist refreshed the standard way silently stopped hot-reloading.
+//
+// The fix watches the parent directory and treats Create/Rename/Write on the
+// target basename as reload triggers. This test replaces a watched IP blacklist
+// via rename and asserts the new entry is actually enforced, then writes the
+// file in place to prove the watch survived the rename (the old code left it
+// dead) and the original Write behaviour still works.
+//
+// The reload is asynchronous, so both assertions poll with Eventually rather
+// than a fixed sleep.
+func TestFileWatcherReloadsOnAtomicRename(t *testing.T) {
+	logger := zap.NewNop()
+	dir := t.TempDir()
+	blFile := filepath.Join(dir, "ip_blacklist.txt")
+	require.NoError(t, os.WriteFile(blFile, []byte("203.0.113.1\n"), 0o644))
+
+	m := &Middleware{
+		logger:          logger,
+		blacklistLoader: NewBlacklistLoader(logger),
+		IPBlacklistFile: blFile,
+		ipBlacklist:     iptrie.NewTrie(),
+	}
+	require.NoError(t, m.loadIPBlacklist(blFile, m.ipBlacklist))
+	require.True(t, m.isIPBlacklisted("203.0.113.1:1"), "seed entry must be enforced")
+	require.False(t, m.isIPBlacklisted("198.51.100.9:1"))
+
+	m.startFileWatcher([]string{blFile})
+	// Give the goroutine a moment to arm its directory watch before we mutate.
+	time.Sleep(150 * time.Millisecond)
+
+	// 1) Atomic update: temp write + rename over the target (replaces the inode).
+	writeAtomic(t, dir, blFile, "203.0.113.1\n198.51.100.9\n")
+	require.Eventually(t, func() bool { return m.isIPBlacklisted("198.51.100.9:1") },
+		3*time.Second, 25*time.Millisecond,
+		"an atomic rename over the watched file must trigger a reload")
+
+	// 2) The watch must still be alive after the rename: a subsequent in-place
+	//    write is also picked up. This is the regression guard -- the old
+	//    file-inode watch was left dead by the rename.
+	require.NoError(t, os.WriteFile(blFile, []byte("203.0.113.1\n198.51.100.9\n192.0.2.5\n"), 0o644))
+	require.Eventually(t, func() bool { return m.isIPBlacklisted("192.0.2.5:1") },
+		3*time.Second, 25*time.Millisecond,
+		"an in-place write after an atomic rename must still trigger a reload")
+}


### PR DESCRIPTION
## What

The file watcher (`startFileWatcher`) missed **atomic file updates** — the standard `write temp + os.Rename over target` pattern used to refresh blocklists and rule files. After such an update the watch went permanently deaf and the file stopped hot-reloading.

## Root cause

`watcher.Add(file)` watches the file **inode**, and only `fsnotify.Write` was handled. An atomic rename replaces the target's inode: fsnotify fires `Rename`/`Remove` on the old, now-dead inode, no `Write` ever arrives, and the watch is left dead.

## Fix

- Watch the **parent directory** instead of the file inode, and filter events by the target **basename**. The directory inode is stable, so the watch survives the rename with **no re-arming**.
- Treat **`Create` / `Rename` / `Write`** as reload triggers (`Create` is inotify's `IN_MOVED_TO` for a rename-into-place). A bare `Remove` (deletion with no replacement) is ignored.
- The existing in-place **`Write`** behaviour is preserved.

## Bonus: a pre-existing race on the same path

Making hot-reload actually fire surfaced a data race under `-race`: `isIPBlacklisted` probed `m.ipBlacklist == nil` **outside** the `RLock`, racing `ReloadConfig`'s locked swap (which the working hot reload performs). The probe was **redundant** — there is already a nil check on the locked snapshot below it — so it's dropped. `go test -race ./...` is now clean.

## Test

`file_watcher_test.go` replaces a watched IP blacklist via `os.Rename` and asserts (end-to-end, via `isIPBlacklisted`) that the new entry is enforced, then writes the file in place to prove the watch **survived the rename** (the old inode watch was left dead) and `Write` still fires.

- ✅ passes on the fix, including under `-race`
- ✅ **fails on the old inode-watch code** ("Condition never satisfied" on the rename) — a genuine regression guard

`go test ./...` is green before and after; `go test -race ./...` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)