### PR TITLE
fix: POST body reaches upstream empty → 502 on every request with a body

### DIFF
--- a/body_passthrough_test.go
+++ b/body_passthrough_test.go
@@ -1,0 +1,132 @@
+package caddywaf
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/phemmer/go-iptrie"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// bodyProbeMiddleware builds a middleware whose only rules target BODY, so the
+// request-body extractor runs on every request and must put the body back.
+func bodyProbeMiddleware(t *testing.T, ruleCount int) *Middleware {
+	t.Helper()
+	logger := zap.NewNop()
+	rules := make([]Rule, ruleCount)
+	for i := range rules {
+		rules[i] = Rule{
+			ID:      "body-probe",
+			Pattern: "zzz-never-matches-zzz",
+			Targets: []string{"BODY"},
+			Phase:   2, Score: 1, Action: "log",
+			regex: regexp.MustCompile("zzz-never-matches-zzz"),
+		}
+	}
+	return &Middleware{
+		logger:                logger,
+		blacklistLoader:       NewBlacklistLoader(logger),
+		AnomalyThreshold:      1000, // score only, never block
+		ruleCache:             NewRuleCache(),
+		ipBlacklist:           iptrie.NewTrie(),
+		dnsBlacklist:          map[string]struct{}{},
+		ruleHitsByPhase:       map[int]int64{},
+		Rules:                 map[int][]Rule{2: rules},
+		requestValueExtractor: NewRequestValueExtractor(logger, false, 0),
+	}
+}
+
+// TestPOSTBodyReachesUpstreamIntact pins the request-body passthrough.
+//
+// extractBody read the body with io.ReadAll(io.LimitReader(r.Body, max)) and
+// then "restored" it by splicing the already-consumed r.Body into an
+// io.MultiReader. With more than one BODY extraction (any config with multiple
+// BODY-targeting rules -- the common case), the reconstructed stream stopped
+// yielding the bytes while r.ContentLength kept its original value. The upstream
+// transport then saw "ContentLength=N with Body length 0", broke the connection,
+// and every POST carrying a body failed with a 502.
+//
+// The downstream handler must read the full, intact body, and Content-Length
+// must still match it. Runs with several BODY rules so the extractor fires more
+// than once, which is what actually triggered the corruption.
+func TestPOSTBodyReachesUpstreamIntact(t *testing.T) {
+	const payload = "hello=world&n=42&msg=a%20test"
+
+	for _, rc := range []int{1, 3} {
+		t.Run("body_rules="+strings.Repeat("x", rc), func(t *testing.T) {
+			m := bodyProbeMiddleware(t, rc)
+
+			var gotBody string
+			var gotLen int64
+			var readErr error
+			var upstreamReq *http.Request
+			next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+				upstreamReq = r
+				b, err := io.ReadAll(r.Body)
+				readErr = err
+				gotBody = string(b)
+				gotLen = r.ContentLength
+				w.WriteHeader(http.StatusOK)
+				return nil
+			})
+
+			req := httptest.NewRequest(http.MethodPost, testURL+"/socket.io/?EIO=4&transport=polling", strings.NewReader(payload))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.RemoteAddr = "203.0.113.5:1234"
+			rec := httptest.NewRecorder()
+
+			require.NoError(t, m.ServeHTTP(rec, req, next))
+			require.NoError(t, readErr)
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, payload, gotBody, "upstream must read the full, intact request body")
+			assert.Equal(t, int64(len(payload)), gotLen, "Content-Length must still match the body the upstream can read")
+
+			// GetBody must be usable on the request the upstream receives, so the
+			// transport can rebuild the body for retries/redirects.
+			require.NotNil(t, upstreamReq.GetBody, "GetBody must be set for transport retries")
+			rc2, err := upstreamReq.GetBody()
+			require.NoError(t, err)
+			replay, err := io.ReadAll(rc2)
+			require.NoError(t, err)
+			assert.Equal(t, payload, string(replay), "GetBody must reproduce the full body")
+		})
+	}
+}
+
+// TestPOSTBodyLargerThanLimitForwardedIntact guards uploads: a request body
+// larger than the inspection limit must still reach the upstream whole. The
+// WAF inspects only the first max_request_body_size bytes but must forward the
+// complete body, or a large POST/upload would be silently truncated.
+func TestPOSTBodyLargerThanLimitForwardedIntact(t *testing.T) {
+	m := bodyProbeMiddleware(t, 1)
+	m.MaxRequestBodySize = 8 // tiny inspection window; body below is larger
+
+	payload := strings.Repeat("A", 8) + strings.Repeat("B", 40) // 48 bytes, 8 inspected
+
+	var gotBody string
+	var gotLen int64
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		gotBody = string(b)
+		gotLen = r.ContentLength
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, testURL+"/upload", strings.NewReader(payload))
+	req.RemoteAddr = "203.0.113.5:1234"
+	rec := httptest.NewRecorder()
+
+	require.NoError(t, m.ServeHTTP(rec, req, next))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, payload, gotBody, "the full body must reach the upstream even when larger than the inspection window")
+	assert.Equal(t, int64(len(payload)), gotLen, "Content-Length must match the forwarded body")
+}

--- a/handler.go
+++ b/handler.go
@@ -53,6 +53,17 @@ func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next cadd
 	// as {http.vars.waf_log_id}, allowing correlation between WAF and access logs.
 	caddyhttp.SetVar(r.Context(), "waf_log_id", logID)
 
+	// Buffer the request body once, up front, when a rule will read it. Rule
+	// extraction runs against per-rule request copies (handlePhase clones the
+	// request via WithContext to tag the rule id), so a body consumed and
+	// "restored" there never reaches the request handed to next -- the upstream
+	// then saw an empty body and every POST with a body failed with a 502.
+	// Capturing it here, on the request that flows downstream, and reading it
+	// from the context during extraction keeps the body intact for the upstream.
+	if m.hasRequestBodyRules() {
+		r = m.captureRequestBody(r)
+	}
+
 	m.incrementTotalRequestsMetric()
 
 	// Initialize WAF state for this request
@@ -189,6 +200,49 @@ func getLogID(ctx context.Context) string {
 // none is, the response body never has to be held in memory at all.
 func (m *Middleware) hasResponseBodyRules() bool {
 	return len(m.Rules[4]) > 0
+}
+
+// hasRequestBodyRules reports whether any request-phase rule reads the request
+// body (a BODY / REQUEST_BODY target, or a JSON_PATH: target). When none do,
+// ServeHTTP leaves the body untouched so it streams straight through.
+func (m *Middleware) hasRequestBodyRules() bool {
+	for _, phase := range []int{1, 2, 3} {
+		for _, rule := range m.Rules[phase] {
+			for _, t := range rule.Targets {
+				u := strings.ToUpper(strings.TrimSpace(t))
+				if u == "BODY" || u == "REQUEST_BODY" || strings.HasPrefix(u, "JSON_PATH:") {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// captureRequestBody buffers the request body once and stashes the inspection
+// window in the request context, so rule extraction reads it without draining
+// r.Body -- the body the upstream still needs.
+//
+// A body within the inspection limit is handed downstream fully re-readable
+// (bytes.Reader) with GetBody set, so the upstream and its retries get the exact
+// bytes. A body larger than the limit is forwarded whole -- the buffered prefix
+// followed by the un-read remainder -- while only the prefix is inspected;
+// GetBody is left unset because that tail is a one-shot stream. Either way the
+// upstream receives the complete body, which the previous restore did not.
+func (m *Middleware) captureRequestBody(r *http.Request) *http.Request {
+	if r.Body == nil || r.Body == http.NoBody {
+		return r
+	}
+	limit := m.MaxRequestBodySize
+	if limit <= 0 {
+		limit = 10 * 1024 * 1024 // 10MB, matching the extractor default
+	}
+	buf, err := bufferRequestBody(r, limit)
+	if err != nil {
+		m.logger.Warn("Failed to buffer request body; leaving it untouched", zap.Error(err))
+		return r
+	}
+	return r.WithContext(context.WithValue(r.Context(), bodyBufferKey{}, buf))
 }
 
 // handleResponseBodyPhase processes Phase 4 (response body).

--- a/request.go
+++ b/request.go
@@ -1,6 +1,7 @@
 package caddywaf
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -8,7 +9,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"unsafe"
 
 	"go.uber.org/zap"
 )
@@ -222,6 +222,62 @@ func (rve *RequestValueExtractor) logIfEmpty(value string, target string, messag
 }
 
 // Helper function to extract body
+// bodyBufferKey carries the buffered request body (the inspection window) in the
+// request context. ServeHTTP captures the body once via captureRequestBody, so
+// extraction reads it here without draining r.Body -- the body the upstream
+// still needs.
+type bodyBufferKey struct{}
+
+// bufferRequestBody reads up to limit bytes of the request body for inspection
+// and rebuilds r.Body so the full body still reaches downstream and the upstream
+// proxy. It returns the inspection window (at most limit bytes).
+//
+// A body within the limit is made fully re-readable (bytes.Reader) with GetBody
+// set, so the upstream and its retries get the exact bytes. A larger body is
+// forwarded whole -- the buffered prefix followed by the un-read remainder --
+// while only the prefix is inspected; GetBody is left unset because that tail is
+// a one-shot stream.
+//
+// This replaces the previous restore, which spliced an already-consumed r.Body
+// into an io.MultiReader. The reconstructed stream stopped yielding the bytes
+// while r.ContentLength kept its original value, so the upstream saw
+// "ContentLength=N with Body length 0", broke the connection, and every POST
+// carrying a body failed with a 502.
+func bufferRequestBody(r *http.Request, limit int64) ([]byte, error) {
+	// Read the inspection window plus one byte, to learn whether the body
+	// exceeded the window without discarding the overflow.
+	buf, err := io.ReadAll(io.LimitReader(r.Body, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(buf)) <= limit {
+		bodyBytes := buf
+		_ = r.Body.Close()
+		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		r.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+		}
+		return bodyBytes, nil
+	}
+	// Body exceeds the inspection window: forward prefix + remainder, inspect the
+	// prefix only. The original body keeps streaming after the buffered bytes,
+	// and its Closer is preserved.
+	prefix := buf[:limit]
+	original := r.Body
+	r.Body = struct {
+		io.Reader
+		io.Closer
+	}{io.MultiReader(bytes.NewReader(buf), original), original}
+	return prefix, nil
+}
+
+// readAndRestoreBody buffers the body against the extractor's maxBodySize. It is
+// the fallback for extraction paths that were not pre-buffered by ServeHTTP
+// (e.g. a direct unit test).
+func (rve *RequestValueExtractor) readAndRestoreBody(r *http.Request) ([]byte, error) {
+	return bufferRequestBody(r, rve.maxBodySize)
+}
+
 func (rve *RequestValueExtractor) extractBody(r *http.Request, target string) (string, error) {
 	if r.Body == nil {
 		rve.logger.Warn("Request body is nil", zap.String("target", target))
@@ -231,29 +287,20 @@ func (rve *RequestValueExtractor) extractBody(r *http.Request, target string) (s
 		rve.logger.Debug("Request body is empty", zap.String("target", target))
 		return "", fmt.Errorf("request body is empty for target: %s", target)
 	}
-	reader := io.LimitReader(r.Body, rve.maxBodySize)
-	bodyBytes, err := io.ReadAll(reader)
+	// ServeHTTP buffers the body up front and stashes the inspection window in
+	// the context; read it there so extraction never drains the body the
+	// upstream will read.
+	if buf, ok := r.Context().Value(bodyBufferKey{}).([]byte); ok {
+		return string(buf), nil
+	}
+	// Fallback (a caller that did not pre-buffer, e.g. a direct unit test):
+	// consume once and restore.
+	bodyBytes, err := rve.readAndRestoreBody(r)
 	if err != nil {
 		rve.logger.Error("Failed to read request body", zap.Error(err))
 		return "", fmt.Errorf("failed to read request body for target %s: %w", target, err)
 	}
-	// Restore body for next read, verifying if we need to combine with remaining body
-	// We use io.MultiReader to concatenate the bytes we read with the *remaining* bytes in the original body.
-	// This ensures that even if we hit the limit, the downstream consumer can read the full body.
-	// We also ensure the original Closer is preserved.
-	r.Body = &struct {
-		io.Reader
-		io.Closer
-	}{
-		Reader: io.MultiReader(strings.NewReader(string(bodyBytes)), r.Body),
-		Closer: r.Body,
-	}
-
-	// SOTA Pattern: Zero-Copy (avoid allocation for string conversion)
-	if len(bodyBytes) == 0 {
-		return "", nil
-	}
-	return unsafe.String(&bodyBytes[0], len(bodyBytes)), nil
+	return string(bodyBytes), nil
 }
 
 // Helper function to extract all headers
@@ -389,13 +436,15 @@ func (rve *RequestValueExtractor) extractValueForJSONPath(r *http.Request, jsonP
 		return "", fmt.Errorf("request body is empty for target: %s", target)
 	}
 
-	reader := io.LimitReader(r.Body, rve.maxBodySize)
-	bodyBytes, err := io.ReadAll(reader)
-	if err != nil {
-		rve.logger.Error("Failed to read request body", zap.Error(err))
-		return "", fmt.Errorf("failed to read request body for JSON_PATH target %s: %w", target, err)
+	bodyBytes, ok := r.Context().Value(bodyBufferKey{}).([]byte)
+	if !ok {
+		var err error
+		bodyBytes, err = rve.readAndRestoreBody(r)
+		if err != nil {
+			rve.logger.Error("Failed to read request body", zap.Error(err))
+			return "", fmt.Errorf("failed to read request body for JSON_PATH target %s: %w", target, err)
+		}
 	}
-	r.Body = io.NopCloser(strings.NewReader(string(bodyBytes))) // Restore body for next read
 
 	// Use helper method to dynamically extract value based on JSON path (e.g., 'data.items.0.name').
 	unredactedValue, err := rve.extractJSONPath(string(bodyBytes), jsonPath)


### PR DESCRIPTION
## What

Every `POST` carrying a body failed with a **502**. Caddy's `reverse_proxy` logged:

```
net/http: HTTP/1.x transport connection broken: http: ContentLength=2 with Body length 0
```

The WAF drained the request body during rule inspection, so the upstream received an empty body while `Content-Length` kept its original value — breaking socket.io, forms, uploads, and any API behind the WAF. `GET` was unaffected.

## Root cause (two parts)

1. `extractBody` read the body and "restored" it by splicing the **already-consumed** `r.Body` into an `io.MultiReader`, which broke across multiple BODY extractions.
2. More fundamentally, `handlePhase` evaluates rules against **per-rule request copies** (it clones the request via `WithContext` to tag the rule id). Any `r.Body` reassigned there is discarded with the copy — it never reaches the request `ServeHTTP` hands to `next`. The shared underlying body was left drained, so the upstream read nothing. *(A restore confined to `extractBody` does not fix this — confirmed empirically: the regression test still failed until the body was buffered on the propagating request.)*

## Fix

- **Buffer the request body once, up front in `ServeHTTP`**, on the request that flows downstream, and stash the inspection window in the request context. Rule extraction reads that buffer instead of draining `r.Body`.
- A body **within** the inspection limit is handed downstream fully re-readable (`bytes.Reader`) with **`GetBody` set**, so transport retries/redirects work.
- A body **larger** than the limit is **forwarded whole** — buffered prefix + the un-read remainder — while only the prefix is inspected (no upload truncation).
- Buffering is **gated on rules that actually read the body** (`hasRequestBodyRules`), so body-less configs stream through untouched.
- Both extractor read paths (`BODY`, `JSON_PATH:`) now share one `bufferRequestBody` helper; the `unsafe.String` aliasing is gone.

## Tests

- `TestPOSTBodyReachesUpstreamIntact` — a POST body through the middleware is read intact by the downstream handler, `Content-Length` matches, and `GetBody` reproduces it (with one and several BODY rules). **Fails on the old code** (empty body, nil `GetBody`).
- `TestPOSTBodyLargerThanLimitForwardedIntact` — a body larger than the inspection window still reaches the upstream whole.
- The pre-existing `TestMiddleware_RequestBodyRestoration` (full body preserved past the limit) still passes.
- `go test ./...` and `go test -race ./...` are green.

## Follow-up (not in this PR)

Reported alongside this: with `anomaly_threshold 20`, legitimate `/socket.io/?...&transport=polling&sid=...` requests accrue score from the `ssrf-attacks` rules up to 24 → 403. Worth tightening the SSRF patterns so they don't match benign socket.io query strings — happy to do that as a separate rules-tuning PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)