### PR TITLE
feat: whitelist_file — load whitelisted IPs from a file, hot-reloaded (#151)

### DIFF
--- a/caddywaf.go
+++ b/caddywaf.go
@@ -175,7 +175,7 @@ func (m *Middleware) Provision(ctx caddy.Context) error {
 	// Start file watchers for rule files and blacklist files
 	// Context cancellation could be added in the future to gracefully stop watchers.
 	m.startFileWatcher(m.RuleFiles)
-	m.startFileWatcher([]string{m.IPBlacklistFile, m.DNSBlacklistFile})
+	m.startFileWatcher([]string{m.IPBlacklistFile, m.DNSBlacklistFile, m.IPWhitelistFile})
 
 	// Configure rate limiting
 	if m.RateLimit.Requests > 0 {
@@ -272,17 +272,11 @@ func (m *Middleware) Provision(ctx caddy.Context) error {
 		}
 	}
 
-	// Build the IP whitelist
-	if len(m.IPWhitelist) > 0 {
-		trie, expanded, err := buildIPWhitelist(m.IPWhitelist)
-		if err != nil {
+	// Build the IP whitelist from inline entries and/or the whitelist file.
+	if len(m.IPWhitelist) > 0 || m.IPWhitelistFile != "" {
+		if err := m.rebuildIPWhitelist(); err != nil {
 			return err
 		}
-		m.ipWhitelist = trie
-		m.logger.Info("IP whitelist loaded",
-			zap.Int("entries", len(expanded)),
-			zap.Strings("ranges", expanded),
-		)
 
 		// Warn loudly when private ranges are exempt. The whitelist matches on
 		// the peer address, which is correct when caddy-waf is the edge but
@@ -546,6 +540,16 @@ func (m *Middleware) ReloadConfig() error {
 		m.mu.Lock()
 		m.dnsBlacklist = newDNSBlacklist
 		m.mu.Unlock()
+	}
+
+	// Rebuild the whitelist (inline entries + file) when a whitelist file is
+	// configured. rebuildIPWhitelist swaps the trie under the lock itself, so it
+	// must be called without holding m.mu.
+	if m.IPWhitelistFile != "" {
+		if err := m.rebuildIPWhitelist(); err != nil {
+			m.logger.Error("Failed to reload IP whitelist", zap.String("file", m.IPWhitelistFile), zap.Error(err))
+			return fmt.Errorf("failed to reload IP whitelist: %v", err)
+		}
 	}
 
 	// loadRules takes m.mu itself, so it must be called without holding it.

--- a/caddywaf.go
+++ b/caddywaf.go
@@ -409,12 +409,32 @@ func (m *Middleware) logVersion() {
 	m.logger.Info("WAF middleware version", zap.String("version", wafVersion))
 }
 
+// isRuleFile reports whether path is one of the configured rule files, so the
+// watcher can pick ReloadRules vs ReloadConfig by identity rather than by a
+// "rule" substring match (which would misroute a blacklist/whitelist file whose
+// path happens to contain "rule").
+func (m *Middleware) isRuleFile(path string) bool {
+	clean := filepath.Clean(path)
+	for _, rf := range m.RuleFiles {
+		if filepath.Clean(rf) == clean {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *Middleware) startFileWatcher(filePaths []string) {
 	for _, path := range filePaths {
-		// Skip watching if the file doesn't exist
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			m.logger.Warn("Skipping file watch, file does not exist",
-				zap.String("file", path),
+		if strings.TrimSpace(path) == "" {
+			continue // unset optional file (e.g. no whitelist_file configured)
+		}
+		// Watch the parent directory, so the target file need not exist yet: a
+		// file created after start (a feed that writes the whitelist/blacklist
+		// later) is picked up via its Create event. Only the directory must
+		// exist now.
+		if _, err := os.Stat(filepath.Dir(path)); err != nil {
+			m.logger.Warn("Skipping file watch, directory does not exist",
+				zap.String("file", path), zap.String("dir", filepath.Dir(path)), zap.Error(err),
 			)
 			continue
 		}
@@ -464,7 +484,7 @@ func (m *Middleware) startFileWatcher(filePaths []string) {
 					}
 					m.logger.Info("Detected configuration change. Reloading...",
 						zap.String("file", file), zap.String("op", event.Op.String()))
-					if strings.Contains(file, "rule") {
+					if m.isRuleFile(file) {
 						if err := m.ReloadRules(); err != nil {
 							m.logger.Error("Failed to reload rules after change", zap.String("file", file), zap.Error(err))
 						} else {

--- a/config.go
+++ b/config.go
@@ -159,6 +159,7 @@ func (cl *ConfigLoader) UnmarshalCaddyfile(d *caddyfile.Dispenser, m *Middleware
 		"rule_file":              cl.parseRuleFile,
 		"ip_blacklist_file":      cl.parseBlacklistFileDirective(true), // Use directive-specific helper
 		"whitelist_ip":           cl.parseWhitelistIP,
+		"whitelist_file":         cl.parseWhitelistFile,
 		"dns_blacklist_file":     cl.parseBlacklistFileDirective(false), // Use directive-specific helper
 		"anomaly_threshold":      cl.parseAnomalyThreshold,
 		"custom_response":        cl.parseCustomResponse,
@@ -509,6 +510,26 @@ func (cl *ConfigLoader) parseWhitelistIP(d *caddyfile.Dispenser, m *Middleware) 
 		zap.String("file", d.File()),
 		zap.Int("line", d.Line()),
 	)
+	return nil
+}
+
+// parseWhitelistFile parses the whitelist_file directive: a file of IP/CIDR
+// entries (one per line, # comments allowed) exempt from the IP-reputation
+// checks, hot-reloaded on change -- the whitelist counterpart to
+// ip_blacklist_file.
+//
+//	whitelist_file /etc/caddy/allowlist.txt
+//
+// The file need not exist at startup: a missing file is skipped with a warning
+// and picked up when it appears (the watcher follows the directory), so a feed
+// that writes the list later works. Malformed lines in the file are skipped
+// with a warning rather than failing the load.
+func (cl *ConfigLoader) parseWhitelistFile(d *caddyfile.Dispenser, m *Middleware) error {
+	if !d.NextArg() {
+		return d.ArgErr()
+	}
+	m.IPWhitelistFile = d.Val()
+	cl.logger.Info("IP whitelist file configured", zap.String("path", m.IPWhitelistFile))
 	return nil
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,6 +90,7 @@ The full list is the `directiveHandlers` map in [`config.go`](https://github.com
 | `ip_blacklist_file` | `<file>` | unset | Path to the IP blacklist (single IPs and CIDR ranges). The file is created empty if it does not exist. |
 | `dns_blacklist_file` | `<file>` | unset | Path to the DNS blacklist (one host per line). The file is created empty if it does not exist. |
 | `whitelist_ip` | `<entry> [<entry> …]` | unset | IPs, CIDR ranges, or the token `private_ranges`, exempt from the **IP-reputation** checks. Repeatable. See [IP whitelist](#ip-whitelist). |
+| `whitelist_file` | `<file>` | unset | Path to a file of IPs/CIDR ranges (one per line, `#` comments allowed) exempt from the **IP-reputation** checks. Hot-reloaded on change — the whitelist counterpart to `ip_blacklist_file`. See [IP whitelist](#ip-whitelist). |
 | `anomaly_threshold` | `<positive int>` | `5` (Caddyfile) / `20` (Provision fallback) | Score at which a request is blocked. Lower values are stricter. |
 | `max_request_body_size` | `<bytes>` | `10485760` (10 MiB) | Upper bound for request body reads via `io.LimitReader`. `0` means "use the default". |
 | `max_response_body_size` | `<bytes>` | `10485760` (10 MiB) | Upper bound on how much of the response body is held in memory for Phase 4 inspection. `0` means "use the default". See [Response body buffering](#response-body-buffering). |
@@ -229,6 +230,29 @@ waf {
 `::1`. Deliberately identical rather than "improved" — a WAF and the server in
 front of it disagreeing about which addresses are private is how bypasses get
 built.
+
+### From a file (`whitelist_file`)
+
+For a long or externally-maintained allowlist — a cloud provider's published
+ranges, a partner's egress IPs, country-blocking exceptions — point
+`whitelist_file` at a text file of IPs and CIDR ranges, one per line (`#`
+comments and blank lines are ignored):
+
+```caddyfile
+waf {
+    whitelist_file /etc/caddy/allowlist.txt
+    # Combine with inline entries; both feed the same whitelist.
+    whitelist_ip private_ranges
+}
+```
+
+The file is **hot-reloaded** on change, exactly like `ip_blacklist_file`, so a
+job that refreshes the list (fetching a provider's ranges, say) takes effect
+without a restart. The file need not exist at startup — it is skipped with a
+warning and picked up when it appears. A malformed line is skipped with a
+warning rather than failing the whole load, so one bad entry in a maintained
+feed does not drop every exemption. Inline `whitelist_ip` entries, by contrast,
+are validated strictly and fail startup on a typo.
 
 An entry that does not parse fails startup. It is not skipped with a warning:
 silently dropping an entry leaves the operator believing an address is exempt

--- a/docs/dynamicupdates.md
+++ b/docs/dynamicupdates.md
@@ -36,6 +36,7 @@ Both functions take the middleware mutex (`m.mu.Lock`) for the duration of the r
 | `rule_file` contents | Yes (atomic). |
 | `ip_blacklist_file` contents | Yes (atomic). |
 | `dns_blacklist_file` contents | Yes (atomic). |
+| `ip_whitelist_file` contents (`whitelist_file`) | Yes (atomic). |
 | `anomaly_threshold` | No. |
 | `metrics_endpoint` | No. |
 | `log_severity` / `log_path` / `log_json` / `log_buffer` | No. |

--- a/ipwhitelist.go
+++ b/ipwhitelist.go
@@ -1,8 +1,10 @@
 package caddywaf
 
 import (
+	"bufio"
 	"fmt"
 	"net/netip"
+	"os"
 	"strings"
 
 	"github.com/phemmer/go-iptrie"
@@ -91,4 +93,79 @@ func (m *Middleware) isIPWhitelisted(remoteAddr string) bool {
 	}
 
 	return trie.Contains(parsed)
+}
+
+// loadIPWhitelistFile reads IP/CIDR entries from path and inserts them into
+// trie, returning the number of valid entries. Blank lines and # comments are
+// ignored. A malformed line is skipped with a warning rather than failing the
+// whole load: a whitelist fed from a maintained external list (a provider's
+// published ranges) should tolerate the odd bad line instead of dropping every
+// exemption. Mirrors the IP blacklist file loader.
+func (m *Middleware) loadIPWhitelistFile(path string, trie *iptrie.Trie) (int, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open whitelist file %q: %w", path, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	valid := 0
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		cidr := line
+		if !strings.Contains(cidr, "/") {
+			cidr = appendCIDR(cidr)
+		}
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			m.logger.Warn("Skipping invalid entry in whitelist file",
+				zap.String("file", path), zap.String("entry", line), zap.Error(err))
+			continue
+		}
+		trie.Insert(prefix, nil)
+		valid++
+	}
+	if err := scanner.Err(); err != nil {
+		return valid, fmt.Errorf("error reading whitelist file %q: %w", path, err)
+	}
+	return valid, nil
+}
+
+// rebuildIPWhitelist builds the whitelist trie from the inline whitelist_ip
+// entries and, if configured, the whitelist_file, then swaps it in under the
+// lock. It is used at Provision and on hot reload. Inline entries are validated
+// strictly (a typo fails startup); file entries are lenient (bad lines skipped),
+// matching the blacklist inline-vs-file split.
+func (m *Middleware) rebuildIPWhitelist() error {
+	trie, expanded, err := buildIPWhitelist(m.IPWhitelist)
+	if err != nil {
+		return err
+	}
+
+	fileEntries := 0
+	if m.IPWhitelistFile != "" {
+		if _, statErr := os.Stat(m.IPWhitelistFile); os.IsNotExist(statErr) {
+			m.logger.Warn("Skipping whitelist file load, file does not exist",
+				zap.String("file", m.IPWhitelistFile))
+		} else {
+			n, loadErr := m.loadIPWhitelistFile(m.IPWhitelistFile, trie)
+			if loadErr != nil {
+				return loadErr
+			}
+			fileEntries = n
+		}
+	}
+
+	m.mu.Lock()
+	m.ipWhitelist = trie
+	m.mu.Unlock()
+
+	m.logger.Info("IP whitelist loaded",
+		zap.Int("inline_entries", len(expanded)),
+		zap.Int("file_entries", fileEntries),
+		zap.String("file", m.IPWhitelistFile))
+	return nil
 }

--- a/types.go
+++ b/types.go
@@ -126,7 +126,11 @@ type Middleware struct {
 	// IPWhitelist holds entries exempt from the IP-reputation checks: bare IPs,
 	// CIDR ranges, or the token "private_ranges". See whitelist_ip in
 	// docs/configuration.md.
-	IPWhitelist      []string            `json:"ip_whitelist,omitempty"`
+	IPWhitelist []string `json:"ip_whitelist,omitempty"`
+	// IPWhitelistFile is an optional file of IP/CIDR entries exempt from the
+	// IP-reputation checks, one per line (# comments allowed). It is hot-reloaded
+	// on change, the whitelist counterpart to ip_blacklist_file. See whitelist_file.
+	IPWhitelistFile  string              `json:"ip_whitelist_file,omitempty"`
 	DNSBlacklistFile string              `json:"dns_blacklist_file"`
 	AnomalyThreshold int                 `json:"anomaly_threshold"`
 	CountryBlacklist CountryAccessFilter `json:"country_blacklist"`

--- a/whitelist_file_test.go
+++ b/whitelist_file_test.go
@@ -1,0 +1,110 @@
+package caddywaf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+	return p
+}
+
+// TestWhitelistFileLoadsAndCombinesWithInline pins that whitelist_file entries
+// are loaded and exempt addresses, alongside inline whitelist_ip entries, and
+// that a malformed line is skipped rather than failing the whole load.
+func TestWhitelistFileLoadsAndCombinesWithInline(t *testing.T) {
+	logger := zap.NewNop()
+	dir := t.TempDir()
+	path := writeFile(t, dir, "allow.txt",
+		"# provider ranges\n203.0.113.7\n198.51.100.0/24\nnot-an-ip\n")
+
+	m := &Middleware{
+		logger:          logger,
+		IPWhitelist:     []string{"192.0.2.5"}, // inline
+		IPWhitelistFile: path,
+	}
+	require.NoError(t, m.rebuildIPWhitelist())
+
+	for _, tc := range []struct {
+		addr string
+		want bool
+	}{
+		{"203.0.113.7:12345", true}, // exact, from file
+		{"198.51.100.42:80", true},  // inside the file CIDR
+		{"192.0.2.5:443", true},     // inline entry
+		{"8.8.8.8:53", false},       // not whitelisted
+	} {
+		assert.Equalf(t, tc.want, m.isIPWhitelisted(tc.addr), "isIPWhitelisted(%q)", tc.addr)
+	}
+}
+
+// TestWhitelistFileHotReloadViaReloadConfig pins that a change to the whitelist
+// file is picked up by ReloadConfig, the hot-reload path the watcher drives.
+func TestWhitelistFileHotReloadViaReloadConfig(t *testing.T) {
+	logger := zap.NewNop()
+	dir := t.TempDir()
+	path := writeFile(t, dir, "allow.txt", "203.0.113.7\n")
+
+	m := &Middleware{
+		logger:          logger,
+		blacklistLoader: NewBlacklistLoader(logger),
+		IPWhitelistFile: path,
+	}
+	require.NoError(t, m.rebuildIPWhitelist())
+	require.True(t, m.isIPWhitelisted("203.0.113.7:1"))
+	require.False(t, m.isIPWhitelisted("198.51.100.9:1"))
+
+	require.NoError(t, os.WriteFile(path, []byte("203.0.113.7\n198.51.100.9\n"), 0o644))
+	require.NoError(t, m.ReloadConfig())
+
+	assert.True(t, m.isIPWhitelisted("198.51.100.9:1"), "a new whitelist entry must be enforced after reload")
+	assert.True(t, m.isIPWhitelisted("203.0.113.7:1"))
+}
+
+// TestWhitelistFileWatcherReloadsOnAtomicRename ties whitelist_file to the
+// directory watcher: an atomic update (write temp + rename) is hot-reloaded
+// end to end, exercising the same path a maintained feed would use.
+func TestWhitelistFileWatcherReloadsOnAtomicRename(t *testing.T) {
+	logger := zap.NewNop()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ip_whitelist.txt")
+	require.NoError(t, os.WriteFile(path, []byte("203.0.113.7\n"), 0o644))
+
+	m := &Middleware{
+		logger:          logger,
+		blacklistLoader: NewBlacklistLoader(logger),
+		IPWhitelistFile: path,
+	}
+	require.NoError(t, m.rebuildIPWhitelist())
+	require.True(t, m.isIPWhitelisted("203.0.113.7:1"))
+	require.False(t, m.isIPWhitelisted("198.51.100.9:1"))
+
+	m.startFileWatcher([]string{path})
+	time.Sleep(150 * time.Millisecond) // let the goroutine arm its directory watch
+
+	writeAtomic(t, dir, path, "203.0.113.7\n198.51.100.9\n")
+
+	require.Eventually(t, func() bool { return m.isIPWhitelisted("198.51.100.9:1") },
+		3*time.Second, 25*time.Millisecond,
+		"an atomic rename of the whitelist file must hot-reload the exemptions")
+}
+
+// TestParseWhitelistFileDirective pins the Caddyfile directive wiring.
+func TestParseWhitelistFileDirective(t *testing.T) {
+	cl := NewConfigLoader(zap.NewNop())
+	m := &Middleware{logger: zap.NewNop()}
+	d := caddyfile.NewTestDispenser(`whitelist_file /etc/caddy/allow.txt`)
+	d.Next() // consume the directive name
+	require.NoError(t, cl.parseWhitelistFile(d, m))
+	assert.Equal(t, "/etc/caddy/allow.txt", m.IPWhitelistFile)
+}

--- a/whitelist_file_test.go
+++ b/whitelist_file_test.go
@@ -90,13 +90,40 @@ func TestWhitelistFileWatcherReloadsOnAtomicRename(t *testing.T) {
 	require.False(t, m.isIPWhitelisted("198.51.100.9:1"))
 
 	m.startFileWatcher([]string{path})
-	time.Sleep(150 * time.Millisecond) // let the goroutine arm its directory watch
 
-	writeAtomic(t, dir, path, "203.0.113.7\n198.51.100.9\n")
-
-	require.Eventually(t, func() bool { return m.isIPWhitelisted("198.51.100.9:1") },
-		3*time.Second, 25*time.Millisecond,
+	// Re-apply the atomic update on each poll until the reload is observed: this
+	// avoids a fixed sleep to wait for the watcher goroutine to arm, which is
+	// slow and can still race on a loaded CI runner.
+	require.Eventually(t, func() bool {
+		writeAtomic(t, dir, path, "203.0.113.7\n198.51.100.9\n")
+		return m.isIPWhitelisted("198.51.100.9:1")
+	}, 3*time.Second, 50*time.Millisecond,
 		"an atomic rename of the whitelist file must hot-reload the exemptions")
+}
+
+// TestWhitelistFileCreatedAfterStartIsPickedUp pins the documented promise that
+// whitelist_file need not exist at startup: the watcher follows the directory,
+// so a file written later (a feed populating the list) is loaded on creation.
+func TestWhitelistFileCreatedAfterStartIsPickedUp(t *testing.T) {
+	logger := zap.NewNop()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ip_whitelist.txt") // does NOT exist yet
+
+	m := &Middleware{
+		logger:          logger,
+		blacklistLoader: NewBlacklistLoader(logger),
+		IPWhitelistFile: path,
+	}
+	require.NoError(t, m.rebuildIPWhitelist()) // missing file is skipped with a warning
+	require.False(t, m.isIPWhitelisted("203.0.113.7:1"))
+
+	m.startFileWatcher([]string{path})
+
+	require.Eventually(t, func() bool {
+		writeAtomic(t, dir, path, "203.0.113.7\n")
+		return m.isIPWhitelisted("203.0.113.7:1")
+	}, 3*time.Second, 50*time.Millisecond,
+		"a whitelist file created after start must be picked up by the watcher")
 }
 
 // TestParseWhitelistFileDirective pins the Caddyfile directive wiring.


### PR DESCRIPTION
Closes #151.

## What

Whitelisting could only be configured inline via `whitelist_ip`. This adds the **file counterpart to `ip_blacklist_file`**: a `whitelist_file` directive that loads IP/CIDR exemptions from a text file and **hot-reloads** them on change.

```caddyfile
waf {
    whitelist_file /etc/caddy/allowlist.txt   # one IP/CIDR per line, # comments ok
    whitelist_ip   private_ranges             # combine with inline entries
}
```

Use case from the issue: feed a maintained list — a cloud provider's published ranges, a partner's egress IPs, country-blocking exceptions — and keep it in sync automatically, without a restart.

## Design (mirrors the blacklist loader)

- Inline `whitelist_ip` entries **and** the file feed the **same trie** (`rebuildIPWhitelist`).
- **Inline** entries are validated **strictly** (a typo fails startup); **file** entries are **lenient** (a malformed line is skipped with a warning, not a whole-load failure) — the right behaviour for a maintained external feed, where one bad line shouldn't drop every exemption.
- The file **need not exist at startup**: skipped with a warning and picked up when it appears (the directory-based watcher from #155 supports this).
- `rebuildIPWhitelist` swaps the trie under the lock; it runs at `Provision` and in `ReloadConfig`, and the watcher now covers the whitelist file.
- The whitelist still matches on the **peer address only**, never `X-Forwarded-For` (unchanged) — a client can't forge its way into an exemption.

## Tests

- File load + combination with inline entries + a skipped malformed line.
- Hot-reload via `ReloadConfig`.
- **End-to-end hot-reload through the watcher on an atomic rename** (write temp + `os.Rename`) — exercises the exact path a feed uses.
- Directive wiring.

`go test ./...` and `go test -race ./...` are green. Docs updated (`configuration.md`, `dynamicupdates.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)