### PR TITLE
feat: trusted_proxies + XFF-aware client IP (rate limiter, GeoIP/ASN, REMOTE_IP)

### DIFF
--- a/caddywaf.go
+++ b/caddywaf.go
@@ -291,6 +291,18 @@ func (m *Middleware) Provision(ctx caddy.Context) error {
 		}
 	}
 
+	// Build the trusted-proxy set: the trust boundary for X-Forwarded-For.
+	if len(m.TrustedProxies) > 0 {
+		trie, expanded, err := buildIPTrie(m.TrustedProxies, "trusted_proxies")
+		if err != nil {
+			return err
+		}
+		m.trustedProxies = trie
+		m.logger.Info("Trusted proxies configured",
+			zap.Int("entries", len(expanded)),
+			zap.String("client_ip_header", m.ClientIPHeader))
+	}
+
 	// Load DNS blacklist
 	if m.DNSBlacklistFile != "" {
 		m.dnsBlacklist = make(map[string]struct{})

--- a/clientip.go
+++ b/clientip.go
@@ -1,0 +1,78 @@
+package caddywaf
+
+import (
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+// clientIPKey carries the resolved client IP in the request context, so every
+// consumer (rate limiter, GeoIP/ASN checks, the REMOTE_IP rule target) uses the
+// same value, computed once per request in ServeHTTP.
+type clientIPKey struct{}
+
+// resolveClientIP determines the real client IP under a trust boundary.
+//
+// If no trusted_proxies are configured, or the immediate peer is not one of
+// them, the peer address is returned and every forwarding header is ignored --
+// a client that is not strictly behind a trusted proxy cannot spoof
+// X-Forwarded-For to move its apparent IP past the GeoIP, ASN or REMOTE_IP
+// checks. When the peer IS a trusted proxy, the client is taken from
+// client_ip_header if configured, otherwise by walking X-Forwarded-For from the
+// right and returning the first address that is not itself a trusted proxy --
+// the real client at the far end of a trusted proxy chain.
+//
+// The returned value is a bare IP (no port).
+func (m *Middleware) resolveClientIP(r *http.Request) string {
+	peer := extractIP(r.RemoteAddr)
+	if m.trustedProxies == nil {
+		return peer
+	}
+	peerAddr, err := netip.ParseAddr(peer)
+	if err != nil || !m.trustedProxies.Contains(peerAddr) {
+		return peer // peer is not a trusted proxy: never honour forwarding headers
+	}
+
+	// Peer is trusted. Prefer an explicit single-IP header (e.g. CF-Connecting-IP).
+	if m.ClientIPHeader != "" {
+		if v := strings.TrimSpace(r.Header.Get(m.ClientIPHeader)); v != "" {
+			if ip := extractIP(v); net.ParseIP(ip) != nil {
+				return ip
+			}
+		}
+	}
+
+	// Otherwise walk X-Forwarded-For right-to-left; the first address that is
+	// not itself a trusted proxy is the real client. Multiple XFF header lines
+	// are treated as one list in order.
+	var parts []string
+	for _, xff := range r.Header.Values("X-Forwarded-For") {
+		for _, p := range strings.Split(xff, ",") {
+			if p = strings.TrimSpace(p); p != "" {
+				parts = append(parts, p)
+			}
+		}
+	}
+	for i := len(parts) - 1; i >= 0; i-- {
+		ip := extractIP(parts[i])
+		addr, err := netip.ParseAddr(ip)
+		if err != nil {
+			continue
+		}
+		if !m.trustedProxies.Contains(addr) {
+			return ip
+		}
+	}
+	return peer
+}
+
+// clientIP returns the resolved client IP for the request, using the value
+// computed once in ServeHTTP when present, and resolving on demand otherwise
+// (e.g. a test that drives a phase directly).
+func (m *Middleware) clientIP(r *http.Request) string {
+	if v, ok := r.Context().Value(clientIPKey{}).(string); ok && v != "" {
+		return v
+	}
+	return m.resolveClientIP(r)
+}

--- a/clientip_test.go
+++ b/clientip_test.go
@@ -1,0 +1,160 @@
+package caddywaf
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/phemmer/go-iptrie"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func newResolverMW(t *testing.T, trusted []string, header string) *Middleware {
+	t.Helper()
+	m := &Middleware{logger: zap.NewNop(), ClientIPHeader: header, TrustedProxies: trusted}
+	if len(trusted) > 0 {
+		trie, _, err := buildIPTrie(trusted, "trusted_proxies")
+		require.NoError(t, err)
+		m.trustedProxies = trie
+	}
+	return m
+}
+
+func reqWith(remoteAddr, xff string, hdr map[string]string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	r.RemoteAddr = remoteAddr
+	if xff != "" {
+		r.Header.Set("X-Forwarded-For", xff)
+	}
+	for k, v := range hdr {
+		r.Header.Set(k, v)
+	}
+	return r
+}
+
+// TestResolveClientIP covers the trust boundary: forwarding headers are honoured
+// only when the immediate peer is a trusted proxy, and a spoofed X-Forwarded-For
+// from an untrusted peer is ignored.
+func TestResolveClientIP(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		trusted []string
+		header  string
+		remote  string
+		xff     string
+		hdr     map[string]string
+		want    string
+	}{
+		{
+			name:   "no trusted_proxies: XFF ignored, peer used",
+			remote: "203.0.113.9:4444", xff: "9.9.9.9",
+			want: "203.0.113.9",
+		},
+		{
+			name:    "peer trusted: client taken from XFF",
+			trusted: []string{"10.0.0.0/8"}, remote: "10.0.0.1:5555", xff: "203.0.113.7",
+			want: "203.0.113.7",
+		},
+		{
+			name:    "peer NOT trusted: spoofed XFF ignored",
+			trusted: []string{"10.0.0.0/8"}, remote: "203.0.113.9:5555", xff: "203.0.113.7",
+			want: "203.0.113.9",
+		},
+		{
+			name:    "trusted proxy chain: first untrusted from the right",
+			trusted: []string{"10.0.0.0/8"}, remote: "10.0.0.1:5555",
+			xff:  "203.0.113.7, 10.0.0.9, 10.0.0.2",
+			want: "203.0.113.7",
+		},
+		{
+			name:    "client_ip_header used when peer trusted",
+			trusted: []string{"173.245.48.0/20"}, header: "CF-Connecting-IP",
+			remote: "173.245.48.5:5555", xff: "10.9.9.9",
+			hdr:  map[string]string{"CF-Connecting-IP": "203.0.113.7"},
+			want: "203.0.113.7",
+		},
+		{
+			name:    "client_ip_header ignored when peer NOT trusted",
+			trusted: []string{"173.245.48.0/20"}, header: "CF-Connecting-IP",
+			remote: "198.51.100.4:5555",
+			hdr:    map[string]string{"CF-Connecting-IP": "203.0.113.7"},
+			want:   "198.51.100.4",
+		},
+		{
+			name:    "private_ranges token as trusted set",
+			trusted: []string{"private_ranges"}, remote: "192.168.1.1:5555", xff: "203.0.113.7",
+			want: "203.0.113.7",
+		},
+		{
+			name:    "peer trusted but no forwarding info: peer used",
+			trusted: []string{"10.0.0.0/8"}, remote: "10.0.0.1:5555",
+			want: "10.0.0.1",
+		},
+		{
+			name:    "all XFF entries trusted: peer used",
+			trusted: []string{"10.0.0.0/8"}, remote: "10.0.0.1:5555", xff: "10.0.0.9, 10.0.0.2",
+			want: "10.0.0.1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newResolverMW(t, tc.trusted, tc.header)
+			got := m.resolveClientIP(reqWith(tc.remote, tc.xff, tc.hdr))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestRemoteIPTargetUnderTrustedProxies proves the security property end to end:
+// a rule matching REMOTE_IP sees the real client when it arrives through a
+// trusted proxy, but a client spoofing X-Forwarded-For from an untrusted peer
+// cannot make the rule see the forged address.
+func TestRemoteIPTargetUnderTrustedProxies(t *testing.T) {
+	logger := zap.NewNop()
+	newMW := func() *Middleware {
+		m := &Middleware{
+			logger:                logger,
+			blacklistLoader:       NewBlacklistLoader(logger),
+			AnomalyThreshold:      5,
+			ruleCache:             NewRuleCache(),
+			ipBlacklist:           iptrie.NewTrie(),
+			dnsBlacklist:          map[string]struct{}{},
+			ruleHitsByPhase:       map[int]int64{},
+			TrustedProxies:        []string{"10.0.0.0/8"},
+			requestValueExtractor: NewRequestValueExtractor(logger, false, 0),
+			Rules: map[int][]Rule{2: {{
+				ID: "block-client", Pattern: `^203\.0\.113\.7$`, Targets: []string{"REMOTE_IP"},
+				Phase: 2, Score: 10, Action: "block", regex: regexp.MustCompile(`^203\.0\.113\.7$`),
+			}}},
+		}
+		trie, _, err := buildIPTrie(m.TrustedProxies, "trusted_proxies")
+		require.NoError(t, err)
+		m.trustedProxies = trie
+		return m
+	}
+
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	serve := func(remoteAddr, xff string) int {
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+		req.RemoteAddr = remoteAddr
+		req.Header.Set("X-Forwarded-For", xff)
+		rec := httptest.NewRecorder()
+		require.NoError(t, newMW().ServeHTTP(rec, req, next))
+		return rec.Code
+	}
+
+	// Through a trusted proxy: REMOTE_IP resolves to the forwarded client -> blocked.
+	assert.Equal(t, http.StatusForbidden, serve("10.0.0.1:5555", "203.0.113.7"),
+		"a client arriving through a trusted proxy must be matched on its real IP")
+
+	// Direct/untrusted peer spoofing the same XFF: REMOTE_IP is the peer -> not blocked.
+	assert.Equal(t, http.StatusOK, serve("198.51.100.4:5555", "203.0.113.7"),
+		"a spoofed X-Forwarded-For from an untrusted peer must not match REMOTE_IP")
+}

--- a/config.go
+++ b/config.go
@@ -160,6 +160,8 @@ func (cl *ConfigLoader) UnmarshalCaddyfile(d *caddyfile.Dispenser, m *Middleware
 		"ip_blacklist_file":      cl.parseBlacklistFileDirective(true), // Use directive-specific helper
 		"whitelist_ip":           cl.parseWhitelistIP,
 		"whitelist_file":         cl.parseWhitelistFile,
+		"trusted_proxies":        cl.parseTrustedProxies,
+		"client_ip_header":       cl.parseClientIPHeader,
 		"dns_blacklist_file":     cl.parseBlacklistFileDirective(false), // Use directive-specific helper
 		"anomaly_threshold":      cl.parseAnomalyThreshold,
 		"custom_response":        cl.parseCustomResponse,
@@ -530,6 +532,33 @@ func (cl *ConfigLoader) parseWhitelistFile(d *caddyfile.Dispenser, m *Middleware
 	}
 	m.IPWhitelistFile = d.Val()
 	cl.logger.Info("IP whitelist file configured", zap.String("path", m.IPWhitelistFile))
+	return nil
+}
+
+// parseTrustedProxies parses the trusted_proxies directive: the trust boundary
+// for X-Forwarded-For. Accepts bare IPs, CIDR ranges, or the token
+// private_ranges; repeatable. Validated at Provision time.
+//
+//	trusted_proxies private_ranges 173.245.48.0/20
+func (cl *ConfigLoader) parseTrustedProxies(d *caddyfile.Dispenser, m *Middleware) error {
+	entries := d.RemainingArgs()
+	if len(entries) == 0 {
+		return d.Err("trusted_proxies requires at least one IP, CIDR range, or the token private_ranges")
+	}
+	m.TrustedProxies = append(m.TrustedProxies, entries...)
+	cl.logger.Debug("Trusted proxies added", zap.Strings("entries", entries))
+	return nil
+}
+
+// parseClientIPHeader parses the client_ip_header directive, naming a
+// single-IP header (e.g. CF-Connecting-IP, True-Client-IP, X-Real-IP) consulted
+// for the client IP once the peer is a trusted proxy.
+func (cl *ConfigLoader) parseClientIPHeader(d *caddyfile.Dispenser, m *Middleware) error {
+	if !d.NextArg() {
+		return d.ArgErr()
+	}
+	m.ClientIPHeader = d.Val()
+	cl.logger.Debug("Client IP header set", zap.String("header", m.ClientIPHeader))
 	return nil
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,8 @@ The full list is the `directiveHandlers` map in [`config.go`](https://github.com
 | `dns_blacklist_file` | `<file>` | unset | Path to the DNS blacklist (one host per line). The file is created empty if it does not exist. |
 | `whitelist_ip` | `<entry> [<entry> …]` | unset | IPs, CIDR ranges, or the token `private_ranges`, exempt from the **IP-reputation** checks. Repeatable. See [IP whitelist](#ip-whitelist). |
 | `whitelist_file` | `<file>` | unset | Path to a file of IPs/CIDR ranges (one per line, `#` comments allowed) exempt from the **IP-reputation** checks. Hot-reloaded on change — the whitelist counterpart to `ip_blacklist_file`. See [IP whitelist](#ip-whitelist). |
+| `trusted_proxies` | `<entry> [<entry> …]` | unset | Peers allowed to speak for their clients via `X-Forwarded-For` / `client_ip_header`: bare IPs, CIDR ranges, or `private_ranges`. Repeatable. Empty = ignore forwarding headers. See [Client IP & trusted proxies](#client-ip--trusted-proxies). |
+| `client_ip_header` | `<name>` | unset | A single-IP header (e.g. `CF-Connecting-IP`, `True-Client-IP`, `X-Real-IP`) read for the client IP once the peer is a trusted proxy, instead of `X-Forwarded-For`. |
 | `anomaly_threshold` | `<positive int>` | `5` (Caddyfile) / `20` (Provision fallback) | Score at which a request is blocked. Lower values are stricter. |
 | `max_request_body_size` | `<bytes>` | `10485760` (10 MiB) | Upper bound for request body reads via `io.LimitReader`. `0` means "use the default". |
 | `max_response_body_size` | `<bytes>` | `10485760` (10 MiB) | Upper bound on how much of the response body is held in memory for Phase 4 inspection. `0` means "use the default". See [Response body buffering](#response-body-buffering). |
@@ -311,10 +313,55 @@ trusted here.
 > exempts all traffic through it. In that topology the directive cannot express
 > "exempt this client" at all.
 >
-> Until [#94](https://github.com/fabriziosalmi/caddy-waf/issues/94) adds
-> `trusted_proxies`, and with it a defensible way to act on forwarded addresses,
-> the options behind a proxy are: leave `whitelist_ip` unset, or place the WAF at
-> the edge where the peer address is the client.
+> Behind a proxy, use [`trusted_proxies`](#client-ip--trusted-proxies) to act on
+> the forwarded client address safely, or leave `whitelist_ip` unset, or place
+> the WAF at the edge where the peer address is the client.
+
+## Client IP & trusted proxies
+
+By default the WAF judges a request by its **peer address** (`r.RemoteAddr`) and
+**ignores `X-Forwarded-For`** — a client reaching the WAF directly cannot spoof a
+forwarding header to change its apparent IP.
+
+When the WAF runs behind a reverse proxy or CDN, name the peers allowed to speak
+for their clients with `trusted_proxies`. Only when the immediate peer is within
+that set is a forwarding header honoured; the real client is then the first
+address in `X-Forwarded-For` — walking right-to-left — that is not itself a
+trusted proxy (so a chain of trusted proxies resolves to the client at the far
+end). Alternatively, `client_ip_header` names a single-IP header to read
+instead.
+
+Once resolved, the client IP is used by the **rate limiter**, the **GeoIP
+country and ASN** filters, and the **`REMOTE_IP`** rule target. The IP
+*blacklist* is unchanged: it checks the peer plus every forwarded hop, because
+for blocking, consulting more addresses can only block more.
+
+### Cloudflare example
+
+Cloudflare terminates the connection, so the peer is always a Cloudflare edge IP
+and the real client is in `CF-Connecting-IP`. Trust Cloudflare's ranges and read
+that header:
+
+```caddyfile
+waf {
+    rule_file rules.json
+    trusted_proxies 173.245.48.0/20 103.21.244.0/22 108.162.192.0/18   # Cloudflare's published ranges
+    client_ip_header CF-Connecting-IP
+}
+```
+
+Keep `trusted_proxies` in sync with Cloudflare's published ranges
+(<https://www.cloudflare.com/ips/>). With `whitelist_file`'s sibling pattern a
+job can even refresh the list on disk.
+
+> [!IMPORTANT]
+> **Migration.** Earlier versions trusted `X-Forwarded-For` unconditionally for
+> the GeoIP/ASN checks, which was spoofable when the WAF was reachable directly.
+> The default is now secure — forwarding headers are ignored unless the peer is a
+> configured trusted proxy. **If you run behind a CDN/proxy and filter by the real
+> client's country/ASN, set `trusted_proxies` (and optionally
+> `client_ip_header`)**, or those filters (and the rate limiter, and `REMOTE_IP`
+> rules) will judge the proxy's address instead of the client's.
 
 ---
 

--- a/handler.go
+++ b/handler.go
@@ -53,6 +53,11 @@ func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next cadd
 	// as {http.vars.waf_log_id}, allowing correlation between WAF and access logs.
 	caddyhttp.SetVar(r.Context(), "waf_log_id", logID)
 
+	// Resolve the real client IP once, under the trusted_proxies boundary, and
+	// carry it in context so the rate limiter, GeoIP/ASN checks and the
+	// REMOTE_IP rule target all agree on one value.
+	r = r.WithContext(context.WithValue(r.Context(), clientIPKey{}, m.resolveClientIP(r)))
+
 	// Buffer the request body once, up front, when a rule will read it. Rule
 	// extraction runs against per-rule request copies (handlePhase clones the
 	// request via WithContext to tag the rule id), so a body consumed and
@@ -427,8 +432,8 @@ func (m *Middleware) handlePhase(w http.ResponseWriter, r *http.Request, phase i
 		// Rate limiting
 		if m.rateLimiter != nil {
 			m.logger.Debug("Starting rate limiting phase")
-			ip := extractIP(r.RemoteAddr) // Pass the logger here
-			path := r.URL.Path            // Get the request path
+			ip := m.clientIP(r) // XFF-aware under trusted_proxies (#94)
+			path := r.URL.Path  // Get the request path
 			if m.rateLimiter.isRateLimited(ip, path) {
 				m.incrementRateLimiterBlockedRequestsMetric() // Increment the counter in the Middleware
 				m.blockRequest(w, r, state, http.StatusTooManyRequests, "rate_limit", "rate_limit_rule",
@@ -445,7 +450,7 @@ func (m *Middleware) handlePhase(w http.ResponseWriter, r *http.Request, phase i
 		// Whitelisting
 		if m.CountryWhitelist.Enabled && !ipExempt {
 			m.logger.Debug("Starting country whitelisting phase")
-			clientIP := getClientIP(r)
+			clientIP := m.clientIP(r)
 			allowed, err := m.isCountryInList(clientIP, m.CountryWhitelist.CountryList, m.CountryWhitelist.geoIP)
 			if err != nil {
 				m.logRequest(zapcore.ErrorLevel, "Failed to check country whitelist",
@@ -478,7 +483,7 @@ func (m *Middleware) handlePhase(w http.ResponseWriter, r *http.Request, phase i
 		// ASN Blocking
 		if m.BlockASNs.Enabled && !ipExempt {
 			m.logger.Debug("Starting ASN blocking phase")
-			clientIP := getClientIP(r)
+			clientIP := m.clientIP(r)
 			blocked, err := m.geoIPHandler.IsASNInList(clientIP, m.BlockASNs.BlockedASNs, m.BlockASNs.geoIP)
 			if err != nil {
 				m.logRequest(zapcore.ErrorLevel, "Failed to check ASN blocking",
@@ -513,7 +518,7 @@ func (m *Middleware) handlePhase(w http.ResponseWriter, r *http.Request, phase i
 		// Blacklisting
 		if m.CountryBlacklist.Enabled && !ipExempt {
 			m.logger.Debug("Starting country blacklisting phase")
-			clientIP := getClientIP(r)
+			clientIP := m.clientIP(r)
 			blocked, err := m.isCountryInList(clientIP, m.CountryBlacklist.CountryList, m.CountryBlacklist.geoIP)
 			if err != nil {
 				m.logRequest(zapcore.ErrorLevel, "Failed to check country blacklisting",

--- a/helpers.go
+++ b/helpers.go
@@ -2,7 +2,6 @@ package caddywaf
 
 import (
 	"net"
-	"net/http"
 	"os"
 	"strings"
 )
@@ -55,20 +54,4 @@ func extractIP(remoteAddr string) string {
 		return remoteAddr
 	}
 	return host
-}
-
-// getClientIP returns the real client IP, checking X-Forwarded-For header first.
-// Falls back to RemoteAddr if X-Forwarded-For is empty or contains invalid data.
-func getClientIP(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		ips := strings.Split(xff, ",")
-		if len(ips) > 0 {
-			clientIP := strings.TrimSpace(ips[0])
-			// Validate the IP before returning
-			if clientIP != "" && net.ParseIP(extractIP(clientIP)) != nil {
-				return clientIP
-			}
-		}
-	}
-	return r.RemoteAddr
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,7 +1,6 @@
 package caddywaf
 
 import (
-	"net/http"
 	"os"
 	"testing"
 )
@@ -45,60 +44,6 @@ func TestFileExists(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := fileExists(tt.path); got != tt.want {
 				t.Errorf("fileExists() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestGetClientIP(t *testing.T) {
-	tests := []struct {
-		name       string
-		remoteAddr string
-		xff        string
-		want       string
-	}{
-		{
-			name:       "no X-Forwarded-For, use RemoteAddr",
-			remoteAddr: "192.168.1.1:12345",
-			xff:        "",
-			want:       "192.168.1.1:12345",
-		},
-		{
-			name:       "single IP in X-Forwarded-For",
-			remoteAddr: "10.0.0.1:12345",
-			xff:        "203.0.113.50",
-			want:       "203.0.113.50",
-		},
-		{
-			name:       "multiple IPs in X-Forwarded-For",
-			remoteAddr: "10.0.0.1:12345",
-			xff:        "203.0.113.50, 70.41.3.18, 150.172.238.178",
-			want:       "203.0.113.50",
-		},
-		{
-			name:       "X-Forwarded-For with spaces",
-			remoteAddr: "10.0.0.1:12345",
-			xff:        "  203.0.113.50  ,  70.41.3.18  ",
-			want:       "203.0.113.50",
-		},
-		{
-			name:       "IPv6 in X-Forwarded-For",
-			remoteAddr: "10.0.0.1:12345",
-			xff:        "2001:db8::1",
-			want:       "2001:db8::1",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/", nil)
-			req.RemoteAddr = tt.remoteAddr
-			if tt.xff != "" {
-				req.Header.Set("X-Forwarded-For", tt.xff)
-			}
-
-			if got := getClientIP(req); got != tt.want {
-				t.Errorf("getClientIP() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/ipwhitelist.go
+++ b/ipwhitelist.go
@@ -36,6 +36,14 @@ var privateRanges = []string{
 // silently drops an entry fails in the dangerous direction for the operator
 // (their address is not exempt) and there is no reason to guess.
 func buildIPWhitelist(entries []string) (*iptrie.Trie, []string, error) {
+	return buildIPTrie(entries, "whitelist_ip")
+}
+
+// buildIPTrie compiles IP/CIDR entries (and the private_ranges token) into a
+// prefix trie, returning the expanded entry list. An unparseable entry is an
+// error, not a warning: silently dropping one fails in the dangerous direction.
+// directive names the source for the error message.
+func buildIPTrie(entries []string, directive string) (*iptrie.Trie, []string, error) {
 	trie := iptrie.NewTrie()
 	var expanded []string
 
@@ -58,7 +66,7 @@ func buildIPWhitelist(entries []string) (*iptrie.Trie, []string, error) {
 		}
 		prefix, err := netip.ParsePrefix(cidr)
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid whitelist_ip entry %q: %w", entry, err)
+			return nil, nil, fmt.Errorf("invalid %s entry %q: %w", directive, entry, err)
 		}
 		trie.Insert(prefix, nil)
 	}

--- a/request.go
+++ b/request.go
@@ -109,8 +109,15 @@ func (rve *RequestValueExtractor) extractSingleValue(target string, r *http.Requ
 
 	// Optimization: Use a map for target extraction logic
 	extractionLogic := map[string]func() (string, error){
-		TargetMethod:   func() (string, error) { return r.Method, nil },
-		TargetRemoteIP: func() (string, error) { return r.RemoteAddr, nil },
+		TargetMethod: func() (string, error) { return r.Method, nil },
+		TargetRemoteIP: func() (string, error) {
+			// Resolved under the trusted_proxies boundary in ServeHTTP; falls back
+			// to the raw peer address when not set (e.g. a direct extractor call).
+			if v, ok := r.Context().Value(clientIPKey{}).(string); ok && v != "" {
+				return v, nil
+			}
+			return r.RemoteAddr, nil
+		},
 		TargetProtocol: func() (string, error) { return r.Proto, nil },
 		TargetHost:     func() (string, error) { return r.Host, nil },
 		TargetArgs: func() (string, error) {

--- a/request.go
+++ b/request.go
@@ -116,7 +116,7 @@ func (rve *RequestValueExtractor) extractSingleValue(target string, r *http.Requ
 			if v, ok := r.Context().Value(clientIPKey{}).(string); ok && v != "" {
 				return v, nil
 			}
-			return r.RemoteAddr, nil
+			return extractIP(r.RemoteAddr), nil // bare IP, consistent with the resolved value
 		},
 		TargetProtocol: func() (string, error) { return r.Proto, nil },
 		TargetHost:     func() (string, error) { return r.Host, nil },

--- a/request_test.go
+++ b/request_test.go
@@ -204,7 +204,9 @@ func TestExtractValue_RemoteIP(t *testing.T) {
 
 	value, err := rve.ExtractValue("REMOTE_IP", req, w)
 	assert.NoError(t, err)
-	assert.Equal(t, localIP, value)
+	// REMOTE_IP is the resolved client IP as a bare address (no port), and
+	// without trusted_proxies configured that is the peer IP. See #94.
+	assert.Equal(t, extractIP(localIP), value)
 }
 
 func TestExtractValue_Protocol(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -130,7 +130,16 @@ type Middleware struct {
 	// IPWhitelistFile is an optional file of IP/CIDR entries exempt from the
 	// IP-reputation checks, one per line (# comments allowed). It is hot-reloaded
 	// on change, the whitelist counterpart to ip_blacklist_file. See whitelist_file.
-	IPWhitelistFile  string              `json:"ip_whitelist_file,omitempty"`
+	IPWhitelistFile string `json:"ip_whitelist_file,omitempty"`
+	// TrustedProxies is the trust boundary for X-Forwarded-For: forwarding
+	// headers are honoured only when the immediate peer is within this set (bare
+	// IPs, CIDR ranges, or the token private_ranges). Empty means the peer
+	// address is always used and forwarding headers are ignored. See #94.
+	TrustedProxies []string `json:"trusted_proxies,omitempty"`
+	// ClientIPHeader, when set (e.g. CF-Connecting-IP), is consulted for the
+	// client IP instead of X-Forwarded-For once the peer is a trusted proxy.
+	ClientIPHeader   string              `json:"client_ip_header,omitempty"`
+	trustedProxies   *iptrie.Trie        `json:"-"`
 	DNSBlacklistFile string              `json:"dns_blacklist_file"`
 	AnomalyThreshold int                 `json:"anomaly_threshold"`
 	CountryBlacklist CountryAccessFilter `json:"country_blacklist"`


### PR DESCRIPTION
Closes #94.

## What

Introduces a **trust boundary** for `X-Forwarded-For` and makes client-IP handling consistent across the WAF.

Two gaps this fixes:
- **Rate limiter** keyed on the peer address → behind a CDN every visitor collapsed onto a few edge IPs, breaking per-client limiting.
- **GeoIP country/ASN** trusted the leftmost `X-Forwarded-For` **unconditionally** → a client reaching the WAF directly could **spoof** XFF to slip past those filters. `REMOTE_IP` rules saw only the raw peer.

## How

- **`trusted_proxies`** — the peers allowed to speak for their clients (bare IPs, CIDR ranges, or `private_ranges`).
- `resolveClientIP` honours forwarding headers **only when the immediate peer is trusted**; otherwise it returns the peer and ignores XFF entirely. When the peer is trusted, the client comes from **`client_ip_header`** (e.g. `CF-Connecting-IP`) if set, else from walking `X-Forwarded-For` **right-to-left** to the first non-trusted address (resolving a trusted proxy chain to the real client).
- Resolved **once** in `ServeHTTP`, carried in context, used by the rate limiter, GeoIP/ASN filters and the `REMOTE_IP` target. The IP **blacklist** is unchanged (peer + all hops — safe for blocking).

## Secure by default (migration)

`trusted_proxies` defaults to empty, so forwarding headers are ignored unless configured. This **changes behaviour** for deployments that relied on unauthenticated XFF for GeoIP/ASN — but that behaviour was spoofable. Documented with a **Cloudflare example** and a migration note in `configuration.md`. The old unconditional-trust `getClientIP` helper is removed.

## Tests

- `TestResolveClientIP` — no-trust, trusted peer, **spoof from an untrusted peer**, proxy chains, `client_ip_header`, `private_ranges`.
- `TestRemoteIPTargetUnderTrustedProxies` — end-to-end: a real client through a trusted proxy matches a `REMOTE_IP` rule; a spoofed `X-Forwarded-For` from an untrusted peer does **not**.

`go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)