### PR TITLE
docs: client IP & trusted proxies (#94); correct stale XFF behaviour

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -124,6 +124,7 @@ export default defineConfig({
           { text: 'Blacklists', link: '/blacklists' },
           { text: 'Rate limiting', link: '/ratelimit' },
           { text: 'Country and ASN blocking', link: '/geoblocking' },
+          { text: 'Client IP & trusted proxies', link: '/client-ip' },
           { text: 'Dynamic updates', link: '/dynamicupdates' },
         ],
       },

--- a/docs/client-ip.md
+++ b/docs/client-ip.md
@@ -1,0 +1,75 @@
+# Client IP & trusted proxies
+
+How the WAF decides *who* a request is from — and why that decision needs a trust boundary. Implementation: [`clientip.go`](https://github.com/fabriziosalmi/caddy-waf/blob/main/clientip.go).
+
+## The problem
+
+Every IP-based control needs the real client address. When the WAF is the edge, that is simply the connection's peer (`r.RemoteAddr`). Behind a reverse proxy or CDN it is not: the peer is the proxy, and the client is carried in a forwarding header such as `X-Forwarded-For`.
+
+That header is set by whoever is upstream — including, if the WAF is reachable directly, the client itself. Trusting it blindly lets anyone send `X-Forwarded-For: 1.2.3.4` and impersonate any address, slipping past the GeoIP, ASN and `REMOTE_IP` checks. So a forwarding header is only trustworthy when it comes from a peer you actually trust.
+
+## The model
+
+By default `trusted_proxies` is empty: the WAF uses the **peer address** and **ignores every forwarding header**. A client reaching it directly cannot change its apparent IP.
+
+Configure `trusted_proxies` with the addresses of your proxy or CDN edges. Then, and only when the immediate peer is one of them, the WAF resolves the real client:
+
+1. If `client_ip_header` is set (e.g. `CF-Connecting-IP`), its value is used.
+2. Otherwise `X-Forwarded-For` is walked **right-to-left**, and the first address that is not itself a trusted proxy is the client — so a chain `client, edge-lb, cdn` resolves to `client`.
+
+If the peer is **not** trusted, forwarding headers are ignored entirely — header or no header.
+
+## Directives
+
+| Directive | Value | Default | Meaning |
+|---|---|---|---|
+| `trusted_proxies` | `<entry> [<entry> …]` | unset | Peers allowed to speak for their clients: bare IPs, CIDR ranges, or the token `private_ranges`. Repeatable. Empty = ignore forwarding headers, use the peer. |
+| `client_ip_header` | `<name>` | unset | A single-IP header (`CF-Connecting-IP`, `True-Client-IP`, `X-Real-IP`, …) read for the client IP once the peer is trusted, instead of `X-Forwarded-For`. |
+
+## What uses the resolved client IP
+
+| Subsystem | Address used |
+|---|---|
+| Rate limiter | Resolved client IP — so a CDN's edges don't collapse into one bucket |
+| GeoIP country filter | Resolved client IP |
+| ASN blocking | Resolved client IP |
+| `REMOTE_IP` rule target | Resolved client IP (a bare IP, no port) |
+| IP blacklist | Peer **plus every** `X-Forwarded-For` hop (unchanged) |
+| IP whitelist | Peer **only**, never a forwarding header |
+
+The last two are deliberate asymmetries. The **blacklist** checks every hop because for *blocking*, consulting more addresses can only ever block more, never less. The **whitelist** uses only the peer because for *allowing*, honouring a client-supplied header would let anyone exempt themselves — see [IP whitelist](/configuration#ip-whitelist).
+
+## Cloudflare
+
+Cloudflare terminates the connection, so the peer is always a Cloudflare edge IP and the real client is in `CF-Connecting-IP`:
+
+```caddyfile
+waf {
+    rule_file rules.json
+    trusted_proxies 173.245.48.0/20 103.21.244.0/22 108.162.192.0/18   # Cloudflare's published ranges
+    client_ip_header CF-Connecting-IP
+}
+```
+
+Keep the list in sync with Cloudflare's published ranges (<https://www.cloudflare.com/ips/>). Because [`whitelist_file`](/configuration#ip-whitelist) demonstrates the pattern, a scheduled job can even refresh a ranges file on disk and have it hot-reloaded.
+
+## Generic reverse proxy
+
+Behind an nginx / HAProxy / your-own edge that appends to `X-Forwarded-For`, trust that edge's address — no `client_ip_header` needed, the client is taken from the header:
+
+```caddyfile
+waf {
+    rule_file rules.json
+    trusted_proxies 10.0.0.0/8            # your internal proxy network
+}
+```
+
+> [!IMPORTANT]
+> ## Migration
+>
+> Earlier versions trusted `X-Forwarded-For` **unconditionally** for the GeoIP and ASN checks. That was spoofable whenever the WAF was reachable directly. The default is now secure: forwarding headers are ignored unless the peer is a configured trusted proxy.
+>
+> **If you run behind a CDN or reverse proxy and rely on filtering by the real client's country or ASN — or on per-client rate limiting, or `REMOTE_IP` rules — set `trusted_proxies`** (and, for header-based CDNs, `client_ip_header`). Without it those controls now judge the proxy's address instead of the client's.
+
+> [!WARNING]
+> `trusted_proxies` is a trust boundary: anything you list can set a request's apparent client IP. List only addresses you control or trust — your own edges, your CDN's published ranges. Never `0.0.0.0/0`, and never a range wider than your actual proxy fleet.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,7 +91,7 @@ The full list is the `directiveHandlers` map in [`config.go`](https://github.com
 | `dns_blacklist_file` | `<file>` | unset | Path to the DNS blacklist (one host per line). The file is created empty if it does not exist. |
 | `whitelist_ip` | `<entry> [<entry> …]` | unset | IPs, CIDR ranges, or the token `private_ranges`, exempt from the **IP-reputation** checks. Repeatable. See [IP whitelist](#ip-whitelist). |
 | `whitelist_file` | `<file>` | unset | Path to a file of IPs/CIDR ranges (one per line, `#` comments allowed) exempt from the **IP-reputation** checks. Hot-reloaded on change — the whitelist counterpart to `ip_blacklist_file`. See [IP whitelist](#ip-whitelist). |
-| `trusted_proxies` | `<entry> [<entry> …]` | unset | Peers allowed to speak for their clients via `X-Forwarded-For` / `client_ip_header`: bare IPs, CIDR ranges, or `private_ranges`. Repeatable. Empty = ignore forwarding headers. See [Client IP & trusted proxies](#client-ip--trusted-proxies). |
+| `trusted_proxies` | `<entry> [<entry> …]` | unset | Peers allowed to speak for their clients via `X-Forwarded-For` / `client_ip_header`: bare IPs, CIDR ranges, or `private_ranges`. Repeatable. Empty = ignore forwarding headers. See [Client IP & trusted proxies](/client-ip). |
 | `client_ip_header` | `<name>` | unset | A single-IP header (e.g. `CF-Connecting-IP`, `True-Client-IP`, `X-Real-IP`) read for the client IP once the peer is a trusted proxy, instead of `X-Forwarded-For`. |
 | `anomaly_threshold` | `<positive int>` | `5` (Caddyfile) / `20` (Provision fallback) | Score at which a request is blocked. Lower values are stricter. |
 | `max_request_body_size` | `<bytes>` | `10485760` (10 MiB) | Upper bound for request body reads via `io.LimitReader`. `0` means "use the default". |
@@ -319,49 +319,18 @@ trusted here.
 
 ## Client IP & trusted proxies
 
-By default the WAF judges a request by its **peer address** (`r.RemoteAddr`) and
-**ignores `X-Forwarded-For`** — a client reaching the WAF directly cannot spoof a
-forwarding header to change its apparent IP.
+By default the WAF judges a request by its **peer address** and **ignores
+`X-Forwarded-For`** — a direct client cannot spoof a forwarding header. Behind a
+reverse proxy or CDN, `trusted_proxies` names the peers allowed to speak for
+their clients, and only then is the forwarded client honoured (via
+`X-Forwarded-For`, right-to-left, or a `client_ip_header` such as
+`CF-Connecting-IP`). The resolved client IP feeds the rate limiter, the GeoIP
+country/ASN filters and the `REMOTE_IP` target.
 
-When the WAF runs behind a reverse proxy or CDN, name the peers allowed to speak
-for their clients with `trusted_proxies`. Only when the immediate peer is within
-that set is a forwarding header honoured; the real client is then the first
-address in `X-Forwarded-For` — walking right-to-left — that is not itself a
-trusted proxy (so a chain of trusted proxies resolves to the client at the far
-end). Alternatively, `client_ip_header` names a single-IP header to read
-instead.
-
-Once resolved, the client IP is used by the **rate limiter**, the **GeoIP
-country and ASN** filters, and the **`REMOTE_IP`** rule target. The IP
-*blacklist* is unchanged: it checks the peer plus every forwarded hop, because
-for blocking, consulting more addresses can only block more.
-
-### Cloudflare example
-
-Cloudflare terminates the connection, so the peer is always a Cloudflare edge IP
-and the real client is in `CF-Connecting-IP`. Trust Cloudflare's ranges and read
-that header:
-
-```caddyfile
-waf {
-    rule_file rules.json
-    trusted_proxies 173.245.48.0/20 103.21.244.0/22 108.162.192.0/18   # Cloudflare's published ranges
-    client_ip_header CF-Connecting-IP
-}
-```
-
-Keep `trusted_proxies` in sync with Cloudflare's published ranges
-(<https://www.cloudflare.com/ips/>). With `whitelist_file`'s sibling pattern a
-job can even refresh the list on disk.
-
-> [!IMPORTANT]
-> **Migration.** Earlier versions trusted `X-Forwarded-For` unconditionally for
-> the GeoIP/ASN checks, which was spoofable when the WAF was reachable directly.
-> The default is now secure — forwarding headers are ignored unless the peer is a
-> configured trusted proxy. **If you run behind a CDN/proxy and filter by the real
-> client's country/ASN, set `trusted_proxies` (and optionally
-> `client_ip_header`)**, or those filters (and the rate limiter, and `REMOTE_IP`
-> rules) will judge the proxy's address instead of the client's.
+The default is secure — **behind a CDN you must configure `trusted_proxies`** or
+those controls judge the proxy's address. See
+**[Client IP & trusted proxies](/client-ip)** for the full model, the Cloudflare
+example and the migration note.
 
 ---
 

--- a/docs/geoblocking.md
+++ b/docs/geoblocking.md
@@ -27,12 +27,13 @@ If the configured MMDB file does not exist, the corresponding feature is **disab
 
 ## Source IP selection
 
-GeoIP lookups use `getClientIP` ([`helpers.go`](https://github.com/fabriziosalmi/caddy-waf/blob/main/helpers.go)):
-
-1. If `X-Forwarded-For` is present, the first comma-separated value is used **provided it parses as a valid IP**.
-2. Otherwise `r.RemoteAddr` is used.
-
-The host portion is then extracted (port stripped) and passed to the MMDB reader.
+GeoIP and ASN lookups use the **resolved client IP** under the `trusted_proxies`
+trust boundary: the connection peer by default, or the forwarded client when the
+peer is a configured trusted proxy. Behind a CDN you must set
+[`trusted_proxies`](/client-ip) (and optionally `client_ip_header`) or these
+checks will judge the proxy's address rather than the client's. See
+[Client IP & trusted proxies](/client-ip) for the full model and a Cloudflare
+example.
 
 > [!TIP]
 > **Private and unresolvable addresses.** `whitelist_countries` blocks anything it

--- a/docs/ratelimit.md
+++ b/docs/ratelimit.md
@@ -40,7 +40,13 @@ The bucket key — the value used to count requests against the limit — depend
 
 ## Source IP
 
-The rate limiter uses the host portion of `r.RemoteAddr` (parsed by `net.SplitHostPort`). It does **not** consult `X-Forwarded-For`. If your deployment is behind a trusted reverse proxy that forwards the original client IP only via that header, place the WAF behind a Caddy upstream that rewrites `r.RemoteAddr`, or accept that all traffic shares the proxy's IP for rate-limit purposes.
+The bucket key's IP is the **resolved client IP** under the `trusted_proxies`
+trust boundary — the connection peer by default, or the forwarded client when
+the peer is a configured trusted proxy. Behind a CDN or reverse proxy, set
+[`trusted_proxies`](/client-ip) (and optionally `client_ip_header`) so each
+client is rate-limited on its own address; without it every request through the
+proxy shares the proxy's IP and collapses into one bucket. See
+[Client IP & trusted proxies](/client-ip).
 
 ## Behaviour
 


### PR DESCRIPTION
Prepares the documentation for the `trusted_proxies` / XFF-aware client IP change (#94) **ahead of its release** (no version bump here — the release is held).

## New page: `docs/client-ip.md`
A dedicated **Client IP & trusted proxies** page (added to the sidebar under Configuration):
- the trust model and why forwarding headers need a boundary,
- `trusted_proxies` + `client_ip_header`, the right-to-left `X-Forwarded-For` resolution,
- a table of which subsystem uses which address (and why the blacklist/whitelist are deliberate exceptions),
- a **Cloudflare** and a **generic reverse-proxy** example,
- a prominent **migration + security** note.

## Corrects stale docs
These still described the **pre-#94** behaviour and would contradict the shipped code:
- `geoblocking.md` — said "the first `X-Forwarded-For` value is used" (the old unconditional, spoofable path).
- `ratelimit.md` — said the limiter "does **not** consult `X-Forwarded-For`" and "all traffic shares the proxy's IP".

Both now describe the **resolved client IP under the trust boundary** and link to the new page.

## configuration.md
Keeps the `trusted_proxies` / `client_ip_header` directive rows plus a concise summary that points to the dedicated page.

Docs-only. `npm run docs:build` and the anchor check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)