### PR TITLE
chore: release v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.4.5] - 2026-09-03
+
+### Security
+- **`trusted_proxies`: `X-Forwarded-For` is no longer trusted by default.** The GeoIP country/ASN checks previously honoured `X-Forwarded-For` unconditionally, so a client reaching the WAF directly could spoof it to move its apparent IP past those filters. Client-IP resolution now has a trust boundary: forwarding headers are honoured **only when the immediate peer is a configured trusted proxy**, otherwise the peer address is used and the header is ignored. ([#163](https://github.com/fabriziosalmi/caddy-waf/pull/163), closes [#94](https://github.com/fabriziosalmi/caddy-waf/issues/94))
+
+### Added
+- **`trusted_proxies`** (bare IPs, CIDR ranges, or `private_ranges`) — the peers allowed to speak for their clients. When the peer is trusted, the real client is taken from **`client_ip_header`** (e.g. `CF-Connecting-IP`) if set, else by walking `X-Forwarded-For` right-to-left to the first non-trusted address (resolving a trusted proxy chain). The resolved client IP now feeds the **rate limiter** (so a CDN's edges no longer share one bucket), the **GeoIP country/ASN** filters and the **`REMOTE_IP`** rule target. The IP blacklist is unchanged (peer + all hops). See [Client IP & trusted proxies](https://github.com/fabriziosalmi/caddy-waf/blob/main/docs/client-ip.md).
+
+### Changed
+- Bumped version constant `wafVersion` to `v0.4.5`.
+- `REMOTE_IP` now yields a bare IP (no port), consistent with the resolved client IP.
+- Removed the old `getClientIP` helper that trusted `X-Forwarded-For` unconditionally.
+
+### Migration
+This changes a default in the **secure** direction. **If you run behind a CDN or reverse proxy and rely on filtering by the real client's country/ASN — or on per-client rate limiting, or `REMOTE_IP` rules — set `trusted_proxies`** (and, for header-based CDNs like Cloudflare, `client_ip_header`). Without it, those controls now judge the proxy's address instead of the client's. Full guidance and a Cloudflare example: [docs/client-ip.md](https://github.com/fabriziosalmi/caddy-waf/blob/main/docs/client-ip.md).
+
 ## [v0.4.4] - 2026-09-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Web Application Firewall middleware for the [Caddy](https://caddyserver.com/) 
 
 - **Module ID**: `http.handlers.waf` — [registered in Caddy's package registry](https://caddyserver.com/docs/modules/http.handlers.waf), so the module is selectable on the [download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf)
 - **Go module path**: `github.com/fabriziosalmi/caddy-waf`
-- **Current version**: `v0.4.4` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
+- **Current version**: `v0.4.5` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
 - **License**: AGPL-3.0 — note this is a copyleft licence; check it suits your deployment before integrating
 
 ---
@@ -67,7 +67,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version  {"version":"v0.4.4"}
+INFO  WAF middleware version  {"version":"v0.4.5"}
 INFO  Rate limit configuration  {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded     {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}
@@ -142,11 +142,11 @@ It is also selectable on [caddyserver.com/download](https://caddyserver.com/down
 Images are published to GitHub Container Registry on every release tag, for `linux/amd64` and `linux/arm64`:
 
 ```bash
-docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.4
-docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.4
+docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.5
+docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.5
 ```
 
-Tags are `0.4.4`, `0.4` and `latest` — note there is **no `v` prefix**, unlike the Go module version. Pin an exact version in anything you deploy. See [`docs/docker.md`](docs/docker.md) for volumes, Compose, and hot reload.
+Tags are `0.4.5`, `0.4` and `latest` — note there is **no `v` prefix**, unlike the Go module version. Pin an exact version in anything you deploy. See [`docs/docker.md`](docs/docker.md) for volumes, Compose, and hot reload.
 
 ---
 

--- a/caddywaf.go
+++ b/caddywaf.go
@@ -50,7 +50,7 @@ var (
 )
 
 // Add or update the version constant as needed
-const wafVersion = "v0.4.4" // update this value to the new release version when tagging
+const wafVersion = "v0.4.5" // update this value to the new release version when tagging
 
 // ==================== Initialization and Setup ====================
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     # security fixes, and `latest` leaves no way to name the image you tested
     # against. Swap for `build: .` to run your local checkout instead -- since
     # v0.4.0 that actually compiles the working tree.
-    image: ghcr.io/fabriziosalmi/caddy-waf:0.4.4
+    image: ghcr.io/fabriziosalmi/caddy-waf:0.4.5
     # build: .
     ports:
       - "8080:8080"

--- a/docs/add-package-guide.md
+++ b/docs/add-package-guide.md
@@ -54,7 +54,7 @@ caddy list-modules | grep waf
 ## Pin a version
 
 ```bash
-caddy add-package github.com/fabriziosalmi/caddy-waf@v0.4.4
+caddy add-package github.com/fabriziosalmi/caddy-waf@v0.4.5
 ```
 
 Any tag from the [Releases](https://github.com/fabriziosalmi/caddy-waf/releases)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,16 +7,16 @@ The repository ships a [`Dockerfile`](https://github.com/fabriziosalmi/caddy-waf
 Images are published to GitHub Container Registry on every release tag, for `linux/amd64` and `linux/arm64`:
 
 ```bash
-docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.4
+docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.5
 ```
 
 | Tag | Meaning |
 |---|---|
-| `0.4.4` | An exact release. **Prefer this.** |
+| `0.4.5` | An exact release. **Prefer this.** |
 | `0.4` | Latest patch of the 0.4 line. |
 | `latest` | Latest release, whatever it currently is. |
 
-Note the image tag carries **no `v` prefix**, unlike the Go module version: `caddy add-package …@v0.4.4` but `docker pull …:0.4.4`.
+Note the image tag carries **no `v` prefix**, unlike the Go module version: `caddy add-package …@v0.4.5` but `docker pull …:0.4.5`.
 
 Pin an exact version in anything you deploy. `latest` gives you no way to name the image you tested against, which matters when a release fixes a security defect — see [Security → Advisories](https://github.com/fabriziosalmi/caddy-waf/security/advisories).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ xcaddy build --with github.com/fabriziosalmi/caddy-waf
 Or run the published container image, which needs no Go toolchain:
 
 ```bash
-docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.4
+docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.5
 ```
 
 The module is also selectable on the [Caddy download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf), and `caddy add-package github.com/fabriziosalmi/caddy-waf` works for a one-off install — though Caddy's maintainers have proposed moving that command out of core, so do not build a deployment around it ([#138](https://github.com/fabriziosalmi/caddy-waf/issues/138)).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version          {"version":"v0.4.4"}
+INFO  WAF middleware version          {"version":"v0.4.5"}
 INFO  Rate limit configuration        {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded             {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}
@@ -82,7 +82,7 @@ The module is registered in Caddy's package registry, so an existing Caddy v2.7+
 caddy add-package github.com/fabriziosalmi/caddy-waf
 ```
 
-This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.4.4` if needed.
+This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.4.5` if needed.
 
 The module is also selectable on <https://caddyserver.com/download>.
 
@@ -93,16 +93,16 @@ See [add-package-guide.md](add-package-guide.md) for the full flow, removal, and
 Images are published to GitHub Container Registry on every release tag, for `linux/amd64` and `linux/arm64`. No Go toolchain, no build step:
 
 ```bash
-docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.4
+docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.5
 ```
 
 | Tag | Meaning |
 |---|---|
-| `0.4.4` | An exact release. **Prefer this in deployments.** |
+| `0.4.5` | An exact release. **Prefer this in deployments.** |
 | `0.4` | Latest patch of the 0.4 line. |
 | `latest` | Latest release, whatever it currently is. |
 
-The image tag carries **no `v` prefix**, unlike the Go module version: `@v0.4.4` for `add-package`, `:0.4.4` for `docker pull`.
+The image tag carries **no `v` prefix**, unlike the Go module version: `@v0.4.5` for `add-package`, `:0.4.5` for `docker pull`.
 
 See [docker.md](docker.md) for mounting rule files and blacklists, Docker Compose, and hot reload inside a container.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,7 +41,7 @@ A representative response:
   "dns_blacklist_hits":            0,
   "rate_limiter_requests":         27004,
   "rate_limiter_blocked_requests": 23640,
-  "version":                       "v0.4.4"
+  "version":                       "v0.4.5"
 }
 ```
 


### PR DESCRIPTION
Release prep for **v0.4.5** — a patch over v0.4.4.

## What ships in v0.4.5
- **`trusted_proxies` + XFF-aware client IP** (#163, closes #94). A trust boundary for `X-Forwarded-For`: forwarding headers are honoured only when the immediate peer is a configured trusted proxy. The resolved client IP feeds the rate limiter, GeoIP/ASN filters and the `REMOTE_IP` target. `client_ip_header` (e.g. `CF-Connecting-IP`) supported.

## ⚠️ Security-relevant default change
`X-Forwarded-For` is **no longer trusted unconditionally** — the previous default was spoofable when the WAF was reachable directly. This is a change in the **secure** direction. **Behind a CDN/proxy, set `trusted_proxies`** (and optionally `client_ip_header`) or GeoIP/ASN, rate limiting and `REMOTE_IP` will judge the proxy's address. See the Security + Migration notes in the CHANGELOG and [docs/client-ip.md](https://github.com/fabriziosalmi/caddy-waf/blob/main/docs/client-ip.md).

## This PR
- Bumps `wafVersion` → `v0.4.5`, adds the CHANGELOG entry.
- Updates current-version / image-tag references. ghcr tags carry **no `v` prefix** (`:0.4.5`). Historical references left intact.

## After merge
Tagging `v0.4.5` triggers `release.yml` (binaries + GitHub Release) and `docker.yml` (`:0.4.5`, `:0.4`, `:latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)