### PR TITLE
feat: dashboard M1 backend — recent blocks, top IPs, by-country, reasons (#143)

### DIFF
--- a/caddywaf.go
+++ b/caddywaf.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/oschwald/maxminddb-golang"
@@ -201,6 +202,11 @@ func (m *Middleware) Provision(ctx caddy.Context) error {
 
 	// Initialize GeoIP stats
 	m.geoIPStats = make(map[string]int64)
+
+	// Observability state for the dashboard (#143 M1).
+	m.provisionTime = time.Now()
+	m.topIPsBlocked = make(map[string]int64)
+	m.blockedByReason = make(map[string]int64)
 
 	// Configure GeoIP-based country blacklisting/whitelisting
 	if m.CountryBlacklist.Enabled || m.CountryWhitelist.Enabled {
@@ -726,6 +732,9 @@ func (m *Middleware) handleMetricsRequest(w http.ResponseWriter, r *http.Request
 		"rate_limiter_requests":         rateLimiterTotalRequests,
 		"rate_limiter_blocked_requests": rateLimiterBlockedRequests,
 		"version":                       wafVersion,
+	}
+	for k, v := range m.observabilitySnapshot() {
+		metrics[k] = v
 	}
 
 	jsonMetrics, err := json.Marshal(metrics)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,7 +41,33 @@ A representative response:
   "dns_blacklist_hits":            0,
   "rate_limiter_requests":         27004,
   "rate_limiter_blocked_requests": 23640,
-  "version":                       "v0.4.5"
+  "version":                       "v0.4.5",
+
+  "schema_version":  2,
+  "server_time_ms":  1756876543210,
+  "uptime_seconds":  86400,
+  "top_rules": [
+    { "id": "block-scanners", "hits": 25 },
+    { "id": "xss-attacks",    "hits": 8 }
+  ],
+  "top_ips": {
+    "cap": 50,
+    "distinct_seen": 318,
+    "items": [ { "ip": "203.0.113.7", "blocked": 640 } ]
+  },
+  "by_country":        [ { "country": "RU", "blocked": 900 } ],
+  "blocked_by_reason": { "rule": 1826, "ip_blacklist": 1290, "rate_limit": 640 },
+  "recent": {
+    "cap": 256,
+    "items": [
+      {
+        "ts_ms": 1756876543000, "id": "aca34e69-c2ff-…",
+        "ip": "203.0.113.7", "method": "POST", "path": "/wp-login.php",
+        "reason": "rule", "rule_id": "941100", "status": 403, "score": 10,
+        "country": "RU"
+      }
+    ]
+  }
 }
 ```
 
@@ -60,6 +86,21 @@ A representative response:
 | `rate_limiter_requests` | int | `RateLimiter.totalRequests` | Total requests counted by the rate limiter (under lock). |
 | `rate_limiter_blocked_requests` | int | `RateLimiter.blockedRequests` | Requests blocked by the rate limiter for exceeding the bucket limit. |
 | `version` | string | `wafVersion` constant in [`caddywaf.go`](https://github.com/fabriziosalmi/caddy-waf/blob/main/caddywaf.go) | Build version of the WAF. |
+
+### Dashboard fields (schema 2)
+
+The built-in dashboard (#143) adds the fields below, all **back-compatible** additions — every field above is unchanged. `schema_version` lets a consumer feature-detect them. Rates are not stored server-side: a client derives them by diffing successive snapshots using `server_time_ms`.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `schema_version` | int | Payload schema version (currently `2`). |
+| `server_time_ms` | int | Server wall-clock at scrape time (Unix ms), for client-side rate math. |
+| `uptime_seconds` | int | Seconds since `Provision`; a drop signals a restart (counters reset). |
+| `top_rules` | array of `{id, hits}` | The most-hit rules, sorted, capped at 20 — a pre-sorted view of `rule_hits`. |
+| `top_ips` | `{cap, distinct_seen, items:[{ip, blocked}]}` | The top offending client IPs by block count (capped at 50). `distinct_seen` is how many distinct IPs the bounded counter has tracked. |
+| `by_country` | array of `{country, blocked}` | Blocks per ISO country, when a GeoIP database is configured. |
+| `blocked_by_reason` | object<string,int> | Block counts by category: `rule`, `ip_blacklist`, `dns_blacklist`, `rate_limit`, `country`, `asn`, `error`. |
+| `recent` | `{cap, items:[…]}` | A bounded ring (256) of the most recent **blocked** decisions, newest first. Each item: `ts_ms`, `id` (the WAF log id, correlates with access logs), `ip`, `method`, `path` (≤256 chars), `reason`, `rule_id` (for rule blocks), `status`, `score`, `country`. |
 
 ## Counter semantics
 

--- a/observability.go
+++ b/observability.go
@@ -1,0 +1,181 @@
+package caddywaf
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// Observability limits for the built-in dashboard (#143 M1). All bounded so the
+// metrics endpoint stays cheap and memory cannot grow with attacker traffic.
+const (
+	metricsSchemaVersion = 2
+	recentBlocksCap      = 256  // recent-blocks ring size
+	topIPsCap            = 1000 // distinct offending IPs tracked
+	topIPsEmit           = 50   // offenders returned, by block count
+	topRulesEmit         = 20   // rules returned, by hit count
+	recentPathMax        = 256  // path length stored per recent entry
+)
+
+// recordBlock captures one blocked decision for the dashboard. It is called from
+// blockRequest, the single choke point every block passes through, so each
+// blocked request is recorded exactly once.
+func (m *Middleware) recordBlock(r *http.Request, state *WAFState, statusCode int, reason, ruleID string) {
+	cat := reasonCategory(reason)
+	ip := m.clientIP(r)
+	country := m.lookupCountry(ip)
+
+	rec := blockRecord{
+		TS:      time.Now().UnixMilli(),
+		ID:      getLogID(r.Context()),
+		IP:      ip,
+		Method:  r.Method,
+		Path:    truncate(r.URL.RequestURI(), recentPathMax),
+		Reason:  cat,
+		Status:  statusCode,
+		Score:   state.TotalScore,
+		Country: country,
+	}
+	if cat == "rule" {
+		rec.RuleID = ruleID
+	}
+
+	m.muObs.Lock()
+	m.recentBlocks = append(m.recentBlocks, rec)
+	if len(m.recentBlocks) > recentBlocksCap {
+		m.recentBlocks = m.recentBlocks[len(m.recentBlocks)-recentBlocksCap:]
+	}
+	if m.blockedByReason != nil {
+		m.blockedByReason[cat]++
+	}
+	// Count the offender, but stop admitting new IPs once the map is full so a
+	// flood of distinct sources cannot grow it without bound.
+	if m.topIPsBlocked != nil {
+		if _, seen := m.topIPsBlocked[ip]; seen || len(m.topIPsBlocked) < topIPsCap {
+			m.topIPsBlocked[ip]++
+		}
+	}
+	if country != "" && m.geoIPStats != nil {
+		m.geoIPStats[country]++
+	}
+	m.muObs.Unlock()
+}
+
+// reasonCategory maps the free-form block reason blockRequest receives onto a
+// small stable set for blocked_by_reason and the recent tail.
+func reasonCategory(reason string) string {
+	switch {
+	case strings.Contains(reason, "ip_blacklist"):
+		return "ip_blacklist"
+	case strings.Contains(reason, "dns_blacklist"):
+		return "dns_blacklist"
+	case strings.Contains(reason, "rate_limit"):
+		return "rate_limit"
+	case strings.Contains(reason, "country"):
+		return "country"
+	case strings.Contains(reason, "asn"):
+		return "asn"
+	case strings.Contains(reason, "internal_error"):
+		return "error"
+	case strings.Contains(reason, "Anomaly threshold"), strings.Contains(reason, "Rule action"):
+		return "rule"
+	default:
+		return "other"
+	}
+}
+
+// lookupCountry best-effort resolves the ISO country of ip using whichever GeoIP
+// reader is configured. Returns "" when no country database is available.
+func (m *Middleware) lookupCountry(ip string) string {
+	if m.geoIPHandler == nil {
+		return ""
+	}
+	reader := m.CountryBlacklist.geoIP
+	if reader == nil {
+		reader = m.CountryWhitelist.geoIP
+	}
+	if reader == nil {
+		reader = m.BlockASNs.geoIP
+	}
+	if reader == nil {
+		return ""
+	}
+	return m.geoIPHandler.GetCountryCode(ip, reader)
+}
+
+// observabilitySnapshot builds the dashboard fields added to the /waf_metrics
+// payload. Shared structures are copied under muObs and everything is sorted and
+// serialised outside the lock.
+func (m *Middleware) observabilitySnapshot() map[string]interface{} {
+	type ruleHit struct {
+		ID   string `json:"id"`
+		Hits int64  `json:"hits"`
+	}
+	rules := []ruleHit{}
+	m.ruleHits.Range(func(k, v interface{}) bool {
+		id, _ := k.(RuleID)
+		if c, ok := v.(*atomic.Int64); ok && c != nil {
+			rules = append(rules, ruleHit{ID: string(id), Hits: c.Load()})
+		}
+		return true
+	})
+	sort.Slice(rules, func(i, j int) bool { return rules[i].Hits > rules[j].Hits })
+	if len(rules) > topRulesEmit {
+		rules = rules[:topRulesEmit]
+	}
+
+	type ipCount struct {
+		IP      string `json:"ip"`
+		Blocked int64  `json:"blocked"`
+	}
+	type countryCount struct {
+		Country string `json:"country"`
+		Blocked int64  `json:"blocked"`
+	}
+
+	m.muObs.Lock()
+	recent := make([]blockRecord, len(m.recentBlocks)) // newest first
+	for i, rec := range m.recentBlocks {
+		recent[len(m.recentBlocks)-1-i] = rec
+	}
+	reasons := make(map[string]int64, len(m.blockedByReason))
+	for k, v := range m.blockedByReason {
+		reasons[k] = v
+	}
+	ips := make([]ipCount, 0, len(m.topIPsBlocked))
+	for ip, c := range m.topIPsBlocked {
+		ips = append(ips, ipCount{ip, c})
+	}
+	distinctIPs := len(m.topIPsBlocked)
+	countries := make([]countryCount, 0, len(m.geoIPStats))
+	for cc, c := range m.geoIPStats {
+		countries = append(countries, countryCount{cc, c})
+	}
+	m.muObs.Unlock()
+
+	sort.Slice(ips, func(i, j int) bool { return ips[i].Blocked > ips[j].Blocked })
+	if len(ips) > topIPsEmit {
+		ips = ips[:topIPsEmit]
+	}
+	sort.Slice(countries, func(i, j int) bool { return countries[i].Blocked > countries[j].Blocked })
+
+	return map[string]interface{}{
+		"schema_version":    metricsSchemaVersion,
+		"server_time_ms":    time.Now().UnixMilli(),
+		"uptime_seconds":    int64(time.Since(m.provisionTime).Seconds()),
+		"top_rules":         rules,
+		"top_ips":           map[string]interface{}{"cap": topIPsEmit, "distinct_seen": distinctIPs, "items": ips},
+		"by_country":        countries,
+		"blocked_by_reason": reasons,
+		"recent":            map[string]interface{}{"cap": recentBlocksCap, "items": recent},
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}

--- a/observability_test.go
+++ b/observability_test.go
@@ -1,0 +1,117 @@
+package caddywaf
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/phemmer/go-iptrie"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func obsMiddleware(t *testing.T) *Middleware {
+	t.Helper()
+	logger := zap.NewNop()
+	return &Middleware{
+		logger:                logger,
+		blacklistLoader:       NewBlacklistLoader(logger),
+		AnomalyThreshold:      5,
+		MetricsEndpoint:       "/waf_metrics",
+		ruleCache:             NewRuleCache(),
+		ipBlacklist:           iptrie.NewTrie(),
+		dnsBlacklist:          map[string]struct{}{},
+		ruleHitsByPhase:       map[int]int64{},
+		provisionTime:         time.Now(),
+		topIPsBlocked:         map[string]int64{},
+		blockedByReason:       map[string]int64{},
+		geoIPStats:            map[string]int64{},
+		requestValueExtractor: NewRequestValueExtractor(logger, false, 0),
+		Rules: map[int][]Rule{1: {{
+			ID: "block-uri", Pattern: "/blockme", Targets: []string{"URI"},
+			Phase: 1, Score: 10, Action: "block", regex: regexp.MustCompile("/blockme"),
+		}}},
+	}
+}
+
+// TestMetricsM1Payload pins the dashboard backend slice (#143 M1): blocked
+// requests populate the recent-blocks tail and the aggregates, the payload stays
+// back-compatible, and the new sections are shaped as the frozen schema expects.
+func TestMetricsM1Payload(t *testing.T) {
+	m := obsMiddleware(t)
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	block := func(remote string) {
+		req := httptest.NewRequest(http.MethodPost, testURL+"/blockme?x=1", nil)
+		req.RemoteAddr = remote
+		rec := httptest.NewRecorder()
+		require.NoError(t, m.ServeHTTP(rec, req, next))
+		require.Equal(t, http.StatusForbidden, rec.Code, "the rule must block")
+	}
+	// IP A blocked 3x, IP B 2x.
+	block("203.0.113.7:1111")
+	block("203.0.113.7:2222")
+	block("203.0.113.7:3333")
+	block("198.51.100.9:4444")
+	block("198.51.100.9:5555")
+
+	// Scrape the metrics endpoint.
+	req := httptest.NewRequest(http.MethodGet, testURL+"/waf_metrics", nil)
+	req.RemoteAddr = "10.0.0.1:9999"
+	rec := httptest.NewRecorder()
+	require.NoError(t, m.ServeHTTP(rec, req, next))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var p map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &p))
+
+	// Back-compat: the v0.4.x keys are still there.
+	for _, k := range []string{"total_requests", "blocked_requests", "rule_hits", "rule_hits_by_phase", "version"} {
+		assert.Contains(t, p, k, "back-compat key %q must remain", k)
+	}
+
+	// New envelope.
+	assert.EqualValues(t, 2, p["schema_version"])
+	assert.Contains(t, p, "server_time_ms")
+	assert.Contains(t, p, "uptime_seconds")
+
+	// blocked_by_reason: all five were rule blocks.
+	reasons := p["blocked_by_reason"].(map[string]any)
+	assert.EqualValues(t, 5, reasons["rule"])
+
+	// recent: five entries, newest first, with the expected shape.
+	recent := p["recent"].(map[string]any)
+	assert.EqualValues(t, recentBlocksCap, recent["cap"])
+	items := recent["items"].([]any)
+	require.Len(t, items, 5)
+	first := items[0].(map[string]any)
+	assert.Equal(t, "198.51.100.9", first["ip"], "newest block first")
+	assert.Equal(t, "rule", first["reason"])
+	assert.Equal(t, "block-uri", first["rule_id"])
+	assert.EqualValues(t, http.StatusForbidden, first["status"])
+	assert.Equal(t, "POST", first["method"])
+
+	// top_ips: A(3) before B(2); two distinct.
+	topIPs := p["top_ips"].(map[string]any)
+	assert.EqualValues(t, 2, topIPs["distinct_seen"])
+	ips := topIPs["items"].([]any)
+	require.GreaterOrEqual(t, len(ips), 2)
+	top := ips[0].(map[string]any)
+	assert.Equal(t, "203.0.113.7", top["ip"])
+	assert.EqualValues(t, 3, top["blocked"])
+
+	// top_rules: the rule fired five times.
+	rules := p["top_rules"].([]any)
+	require.NotEmpty(t, rules)
+	r0 := rules[0].(map[string]any)
+	assert.Equal(t, "block-uri", r0["id"])
+	assert.EqualValues(t, 5, r0["hits"])
+}

--- a/response.go
+++ b/response.go
@@ -24,6 +24,9 @@ func (m *Middleware) blockRequest(recorder http.ResponseWriter, r *http.Request,
 	state.StatusCode = statusCode
 	state.ResponseWritten = true
 
+	// Record the decision for the dashboard's recent-blocks tail and aggregates.
+	m.recordBlock(r, state, statusCode, reason, ruleID)
+
 	// CRITICAL FIX: Log at WARN level for visibility
 	m.logger.Warn("REQUEST BLOCKED BY WAF", append(fields,
 		zap.String("rule_id", ruleID),

--- a/types.go
+++ b/types.go
@@ -104,6 +104,21 @@ type WAFState struct {
 	ResponseWritten bool
 }
 
+// blockRecord is one entry in the recent-blocks ring the metrics endpoint
+// exposes for the dashboard (#143). Blocked requests only.
+type blockRecord struct {
+	TS      int64  `json:"ts_ms"`
+	ID      string `json:"id"`
+	IP      string `json:"ip"`
+	Method  string `json:"method"`
+	Path    string `json:"path"`
+	Reason  string `json:"reason"`
+	RuleID  string `json:"rule_id,omitempty"`
+	Status  int    `json:"status"`
+	Score   int    `json:"score"`
+	Country string `json:"country,omitempty"`
+}
+
 // Middleware is the main WAF middleware struct that implements Caddy's
 // Module, Provisioner, Validator, and MiddlewareHandler interfaces.
 //
@@ -183,6 +198,14 @@ type Middleware struct {
 	ruleHitsByPhase map[int]int64
 	geoIPStats      map[string]int64 // Key: country code, Value: count
 	muMetrics       sync.RWMutex     // Mutex for metrics synchronization
+
+	// Observability for the built-in dashboard (#143 M1). geoIPStats above holds
+	// per-country BLOCK counts; the fields below and it are all guarded by muObs.
+	provisionTime   time.Time
+	muObs           sync.Mutex
+	recentBlocks    []blockRecord    // bounded ring, oldest first
+	topIPsBlocked   map[string]int64 // bounded
+	blockedByReason map[string]int64
 
 	rateLimiterBlockedRequests int64        // Add rate limiter blocked requests metric
 	muRateLimiterMetrics       sync.RWMutex // Mutex to protect rate limiter metrics


### PR DESCRIPTION
The first slice of the built-in dashboard backend (#143), on the frozen M1 schema. Extends `/waf_metrics` with **schema_version 2** — all **back-compatible** additions, every existing key unchanged.

## New fields
- **`recent`** — a bounded ring (256) of the most recent **blocked** decisions, newest first: `ts_ms`, `id` (WAF log id, correlates with access logs), `ip`, `method`, `path`, `reason`, `rule_id`, `status`, `score`, `country`. The dashboard's live tail.
- **`top_ips`** — bounded top-50 offending client IPs by block count, with `distinct_seen`; the counter map is capped so a flood of distinct sources can't grow it unbounded.
- **`by_country`** — blocks per ISO country (wires up the previously **dead** `geoIPStats` map).
- **`blocked_by_reason`** — counts by category (`rule`/`ip_blacklist`/`dns_blacklist`/`rate_limit`/`country`/`asn`/`error`).
- **`top_rules`** — a pre-sorted, capped view of `rule_hits`.
- **`server_time_ms` + `uptime_seconds`** — so a client derives rates by diffing snapshots (no server-side time series); an uptime drop signals a restart.

## How
Recording happens **once per block in `blockRequest`** — the single choke point every block passes through — so nothing is double-counted. All new state is behind **one mutex** (`muObs`) and snapshotted under it, then sorted/marshalled outside the lock (the discipline that keeps the metrics endpoint race-free under traffic). Everything is **bounded**.

## Tests
`TestMetricsM1Payload` drives several blocks end-to-end through `ServeHTTP`, then scrapes `/waf_metrics` and asserts the `recent` tail (newest first), `top_ips` ordering + `distinct_seen`, `blocked_by_reason`, `top_rules`, and that **every pre-existing key still present**. `go test ./...` and `-race` green. `docs/metrics.md` documents the schema-2 fields.

Next (M2): the UI shell that renders this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)