### PR TITLE
refactor(dashboard): modular, decoupled UI + automatic light/dark theme (#143)

### DIFF
--- a/caddywaf.go
+++ b/caddywaf.go
@@ -94,6 +94,12 @@ func (m *Middleware) Provision(ctx caddy.Context) error {
 	m.Rules = make(map[int][]Rule) // Initialize Rules map to prevent nil pointer panic
 	m.ipBlacklist = iptrie.NewTrie()
 
+	// Normalise the dashboard path so a configured trailing slash ("/waf/") does
+	// not desync the injected base path from request matching (#170).
+	if m.DashboardEndpoint != "" {
+		m.DashboardEndpoint = "/" + strings.Trim(m.DashboardEndpoint, "/")
+	}
+
 	// Set default log severity if not provided
 	if m.LogSeverity == "" {
 		m.LogSeverity = "info"

--- a/dashboard.go
+++ b/dashboard.go
@@ -7,35 +7,67 @@ import (
 	"go.uber.org/zap"
 )
 
-// isDashboardRequest reports whether r targets the configured dashboard path.
-func (m *Middleware) isDashboardRequest(r *http.Request) bool {
-	return m.DashboardEndpoint != "" && r.URL.Path == m.DashboardEndpoint
+// dashboardAssets maps a request path suffix (relative to DashboardEndpoint) to
+// an embedded file and its content type. index.html is templated at serve time;
+// the CSS and JS are served verbatim. Keeping the page modular (structure /
+// style / behaviour in separate files) rather than one inlined blob is the
+// point of serving more than index.html.
+var dashboardAssets = map[string]struct {
+	file, mime string
+	template   bool
+}{
+	"":               {"ui/index.html", "text/html; charset=utf-8", true},
+	"/":              {"ui/index.html", "text/html; charset=utf-8", true},
+	"/dashboard.css": {"ui/dashboard.css", "text/css; charset=utf-8", false},
+	"/dashboard.js":  {"ui/dashboard.js", "application/javascript; charset=utf-8", false},
 }
 
-// serveDashboard serves the built-in read-only dashboard page.
+// isDashboardRequest reports whether r targets the dashboard path or one of its
+// assets served beneath it.
+func (m *Middleware) isDashboardRequest(r *http.Request) bool {
+	if m.DashboardEndpoint == "" {
+		return false
+	}
+	p := r.URL.Path
+	return p == m.DashboardEndpoint || strings.HasPrefix(p, m.DashboardEndpoint+"/")
+}
+
+// serveDashboard serves the built-in read-only dashboard and its assets.
 //
 // The page ships embedded under the `with_ui` build tag; without it, Assets is
-// empty and the path returns a short notice rather than a blank 404, so the
-// operator knows the directive is set but the binary was built without the UI.
-// The page is served same-origin with the metrics endpoint, which is injected
-// so the browser fetches it with a relative path (no CORS, no hardcoded host).
+// empty and the path returns a short notice rather than a blank 404. index.html
+// is served same-origin with the metrics endpoint, which -- together with the
+// dashboard's own base path -- is injected so the browser fetches everything
+// with relative URLs (no CORS, no hardcoded host).
 func (m *Middleware) serveDashboard(w http.ResponseWriter, r *http.Request) error {
-	page, err := Assets.ReadFile("ui/index.html")
+	suffix := strings.TrimPrefix(r.URL.Path, m.DashboardEndpoint)
+	asset, ok := dashboardAssets[suffix]
+	if !ok {
+		http.NotFound(w, r)
+		return nil
+	}
+
+	body, err := Assets.ReadFile(asset.file)
 	if err != nil {
 		m.logger.Debug("Dashboard requested but UI not compiled", zap.Error(err))
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte("caddy-waf dashboard is not available: this binary was built without the `with_ui` tag.\nRebuild with: xcaddy build --with github.com/fabriziosalmi/caddy-waf (and -tags with_ui).\n"))
+		_, _ = w.Write([]byte("caddy-waf dashboard is not available: this binary was built without the `with_ui` tag.\nRebuild with the with_ui build tag to include the UI.\n"))
 		return nil
 	}
 
-	html := strings.ReplaceAll(string(page), "__WAF_METRICS_PATH__", m.MetricsEndpoint)
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	// The dashboard is read-only and self-contained; forbid embedding and
-	// third-party resources defensively.
+	out := string(body)
+	if asset.template {
+		out = strings.ReplaceAll(out, "__BASE__", strings.TrimRight(m.DashboardEndpoint, "/"))
+		out = strings.ReplaceAll(out, "__WAF_METRICS_PATH__", m.MetricsEndpoint)
+	}
+
+	w.Header().Set("Content-Type", asset.mime)
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	w.Header().Set("X-Frame-Options", "DENY")
+	if asset.template {
+		w.Header().Set("X-Frame-Options", "DENY")
+	}
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(html))
+	_, _ = w.Write([]byte(out))
 	return nil
 }

--- a/dashboard.go
+++ b/dashboard.go
@@ -24,12 +24,20 @@ var dashboardAssets = map[string]struct {
 
 // isDashboardRequest reports whether r targets the dashboard path or one of its
 // assets served beneath it.
+// dashboardBase is the dashboard path with any trailing slash removed, so
+// request matching, asset suffixes and the injected base path all agree even
+// when the directive is configured with a trailing slash.
+func (m *Middleware) dashboardBase() string {
+	return strings.TrimRight(m.DashboardEndpoint, "/")
+}
+
 func (m *Middleware) isDashboardRequest(r *http.Request) bool {
 	if m.DashboardEndpoint == "" {
 		return false
 	}
+	base := m.dashboardBase()
 	p := r.URL.Path
-	return p == m.DashboardEndpoint || strings.HasPrefix(p, m.DashboardEndpoint+"/")
+	return p == base || p == base+"/" || strings.HasPrefix(p, base+"/")
 }
 
 // serveDashboard serves the built-in read-only dashboard and its assets.
@@ -40,7 +48,8 @@ func (m *Middleware) isDashboardRequest(r *http.Request) bool {
 // dashboard's own base path -- is injected so the browser fetches everything
 // with relative URLs (no CORS, no hardcoded host).
 func (m *Middleware) serveDashboard(w http.ResponseWriter, r *http.Request) error {
-	suffix := strings.TrimPrefix(r.URL.Path, m.DashboardEndpoint)
+	base := m.dashboardBase()
+	suffix := strings.TrimPrefix(r.URL.Path, base)
 	asset, ok := dashboardAssets[suffix]
 	if !ok {
 		http.NotFound(w, r)
@@ -58,7 +67,7 @@ func (m *Middleware) serveDashboard(w http.ResponseWriter, r *http.Request) erro
 
 	out := string(body)
 	if asset.template {
-		out = strings.ReplaceAll(out, "__BASE__", strings.TrimRight(m.DashboardEndpoint, "/"))
+		out = strings.ReplaceAll(out, "__BASE__", base)
 		out = strings.ReplaceAll(out, "__WAF_METRICS_PATH__", m.MetricsEndpoint)
 	}
 

--- a/dashboard_with_ui_test.go
+++ b/dashboard_with_ui_test.go
@@ -5,7 +5,6 @@ package caddywaf
 import (
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
@@ -58,7 +57,22 @@ func TestDashboardServesPageWithUI(t *testing.T) {
 	assert.Contains(t, js.Header().Get("Content-Type"), "javascript")
 	assert.Contains(t, js.Body.String(), "wafDashboard")
 
-	// unknown asset under the endpoint is a 404, not the page
-	assert.Equal(t, http.StatusNotFound, serveDash(t, m, "/waf/nope.png").Code)
-	assert.False(t, strings.Contains(js.Body.String(), "__BASE__"))
+	assert.NotContains(t, js.Body.String(), "__BASE__", "JS is served verbatim, no template placeholders")
+
+	// an unknown asset under the endpoint is a 404, and not the dashboard HTML
+	nf := serveDash(t, m, "/waf/nope.png")
+	assert.Equal(t, http.StatusNotFound, nf.Code)
+	assert.NotContains(t, nf.Body.String(), "<title>caddy-waf", "a 404 must not return the dashboard page")
+}
+
+// TestDashboardTrailingSlashConfig pins that a dashboard path configured with a
+// trailing slash still matches and serves its assets (the base is trimmed).
+func TestDashboardTrailingSlashConfig(t *testing.T) {
+	m := dashMiddleware(t)
+	m.DashboardEndpoint = "/waf/"
+	assert.Equal(t, http.StatusOK, serveDash(t, m, "/waf").Code)
+	assert.Equal(t, http.StatusOK, serveDash(t, m, "/waf/").Code)
+	css := serveDash(t, m, "/waf/dashboard.css")
+	assert.Equal(t, http.StatusOK, css.Code)
+	assert.Contains(t, css.Body.String(), ":root")
 }

--- a/dashboard_with_ui_test.go
+++ b/dashboard_with_ui_test.go
@@ -13,28 +13,52 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestDashboardServesPageWithUI runs only under `-tags with_ui`, where the page
-// is embedded. It asserts the WAF serves the HTML same-origin with the metrics
-// path injected, so the browser fetches metrics with a relative URL.
-func TestDashboardServesPageWithUI(t *testing.T) {
-	m := dashMiddleware(t)
+func serveDash(t *testing.T, m *Middleware, path string) *httptest.ResponseRecorder {
+	t.Helper()
 	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-		t.Fatal("upstream must not be reached for the dashboard path")
+		t.Fatalf("upstream must not be reached for dashboard path %q", path)
 		return nil
 	})
-	req := httptest.NewRequest(http.MethodGet, testURL+"/waf", nil)
+	req := httptest.NewRequest(http.MethodGet, testURL+path, nil)
 	req.RemoteAddr = "10.0.0.1:1234"
 	rec := httptest.NewRecorder()
 	require.NoError(t, m.ServeHTTP(rec, req, next))
+	return rec
+}
 
+// TestDashboardServesPageWithUI runs only under `-tags with_ui`, where the page
+// is embedded. It asserts the WAF serves the modular assets same-origin with the
+// metrics path and base path injected, so the browser fetches CSS/JS/metrics
+// with relative URLs.
+func TestDashboardServesPageWithUI(t *testing.T) {
+	m := dashMiddleware(t) // DashboardEndpoint "/waf", MetricsEndpoint "/waf_metrics"
+
+	// index.html
+	rec := serveDash(t, m, "/waf")
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Header().Get("Content-Type"), "text/html")
 	body := rec.Body.String()
 	assert.Contains(t, body, "<title>caddy-waf</title>")
-	// The metrics path is injected, and the placeholder is gone.
-	assert.Contains(t, body, `const METRICS_PATH = "/waf_metrics";`)
-	assert.False(t, strings.Contains(body, "__WAF_METRICS_PATH__"), "placeholder must be replaced")
-	// Self-contained: no third-party runtime requests.
-	assert.False(t, strings.Contains(body, "http://"), "no external http resources")
-	assert.False(t, strings.Contains(body, "cdn"), "no CDN references")
+	assert.Contains(t, body, `content="/waf_metrics"`, "metrics path injected into the meta tag")
+	assert.Contains(t, body, `href="/waf/dashboard.css"`, "base path injected into the stylesheet link")
+	assert.Contains(t, body, `src="/waf/dashboard.js"`, "base path injected into the script src")
+	assert.NotContains(t, body, "__WAF_METRICS_PATH__")
+	assert.NotContains(t, body, "__BASE__")
+	assert.NotContains(t, body, "http://", "no external resources")
+	assert.NotContains(t, body, "cdn", "no CDN references")
+
+	// modular assets served beneath the endpoint
+	css := serveDash(t, m, "/waf/dashboard.css")
+	assert.Equal(t, http.StatusOK, css.Code)
+	assert.Contains(t, css.Header().Get("Content-Type"), "text/css")
+	assert.Contains(t, css.Body.String(), ":root")
+
+	js := serveDash(t, m, "/waf/dashboard.js")
+	assert.Equal(t, http.StatusOK, js.Code)
+	assert.Contains(t, js.Header().Get("Content-Type"), "javascript")
+	assert.Contains(t, js.Body.String(), "wafDashboard")
+
+	// unknown asset under the endpoint is a 404, not the page
+	assert.Equal(t, http.StatusNotFound, serveDash(t, m, "/waf/nope.png").Code)
+	assert.False(t, strings.Contains(js.Body.String(), "__BASE__"))
 }

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,8 +1,8 @@
 # Built-in dashboard
 
-A read-only web dashboard for a live view of what the WAF is doing — requests allowed vs blocked, block rate, top rules, top offending IPs, per-country and per-phase breakdowns, and a tail of the most recent blocked requests. It is **served by the WAF itself**, same-origin with the metrics endpoint: no external stack, no CDN, no third-party runtime requests, one self-contained page.
+A read-only web dashboard for a live view of what the WAF is doing — requests allowed vs blocked, block rate, top rules, top offending IPs, per-country and per-phase breakdowns, and a tail of the most recent blocked requests. It is **served by the WAF itself**, same-origin with the metrics endpoint: no external stack, no CDN, no third-party runtime requests. The page is modular — structure (`ui/index.html`), style (`ui/dashboard.css`) and behaviour (`ui/dashboard.js`, split into decoupled config/store/view/api modules) are separate embedded files, served beneath the dashboard path.
 
-Implementation: [`dashboard.go`](https://github.com/fabriziosalmi/caddy-waf/blob/main/dashboard.go) and [`ui/index.html`](https://github.com/fabriziosalmi/caddy-waf/blob/main/ui/index.html).
+Implementation: [`dashboard.go`](https://github.com/fabriziosalmi/caddy-waf/blob/main/dashboard.go) and [`ui/`](https://github.com/fabriziosalmi/caddy-waf/tree/main/ui).
 
 ## Opt-in at two levels
 
@@ -72,4 +72,4 @@ Everything comes from the metrics payload ([schema 2](/metrics#dashboard-fields-
 - **Top rules**, **top offending source IPs**, **blocks by country**.
 - **Recent blocks** — a live tail of the most recent blocked requests: time, source IP + country, method, path, reason, rule id, score, status.
 
-The page auto-refreshes (2–30s, selectable) and can be paused; it degrades gracefully to the last data if the endpoint becomes unreachable.
+The theme follows the viewer's system light/dark preference automatically (and honours an explicit override). The page auto-refreshes (2–30s, selectable) and can be paused; it degrades gracefully to the last data if the endpoint becomes unreachable.

--- a/ui/dashboard.css
+++ b/ui/dashboard.css
@@ -1,0 +1,98 @@
+/* caddy-waf dashboard — presentation only. Decoupled from markup and logic.
+   Theme is automatic: the bare :root is the dark palette, prefers-color-scheme
+   selects light, and an explicit data-theme on <html> overrides either way. */
+:root {
+  --bg: #0f1419; --panel: #161c24; --panel-2: #1b232d; --line: #26313d;
+  --fg: #e6edf3; --muted: #8b98a5; --faint: #5b6875;
+  --accent: #39d3bb; --ok: #3fb950; --warn: #d29922; --bad: #f85149;
+  --c-rule: #f85149; --c-ip: #d29922; --c-rate: #a371f7; --c-country: #58a6ff;
+  --c-asn: #39d3bb; --c-dns: #db61a2; --c-other: #6e7681;
+  --radius: 10px;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) {
+    --bg:#f5f7fa; --panel:#fff; --panel-2:#f0f3f7; --line:#dde3ea;
+    --fg:#1c2430; --muted:#5b6875; --faint:#93a1af;
+  }
+}
+:root[data-theme="light"] {
+  --bg:#f5f7fa; --panel:#fff; --panel-2:#f0f3f7; --line:#dde3ea;
+  --fg:#1c2430; --muted:#5b6875; --faint:#93a1af;
+}
+:root[data-theme="dark"] {
+  --bg:#0f1419; --panel:#161c24; --panel-2:#1b232d; --line:#26313d;
+  --fg:#e6edf3; --muted:#8b98a5; --faint:#5b6875;
+}
+
+* { box-sizing: border-box; }
+body { margin:0; background:var(--bg); color:var(--fg); font-family:var(--sans);
+  font-size:14px; line-height:1.45; -webkit-font-smoothing:antialiased; }
+.wrap { max-width:1240px; margin:0 auto; padding:20px 20px 60px; }
+
+header { display:flex; align-items:center; gap:14px; flex-wrap:wrap;
+  padding-bottom:16px; border-bottom:1px solid var(--line); margin-bottom:20px; }
+.brand { display:flex; align-items:baseline; gap:10px; }
+.brand h1 { font-size:18px; margin:0; letter-spacing:.2px; font-weight:650; }
+.brand .shield { color:var(--accent); font-size:20px; }
+.ver { font-family:var(--mono); font-size:12px; color:var(--muted);
+  background:var(--panel-2); padding:2px 8px; border-radius:6px; border:1px solid var(--line); }
+.spacer { flex:1; }
+.meta { display:flex; align-items:center; gap:16px; color:var(--muted); font-size:12.5px; }
+.live { display:inline-flex; align-items:center; gap:7px; }
+.dot { width:8px; height:8px; border-radius:50%; background:var(--faint); transition:background .2s; }
+.live.on .dot { background:var(--ok); box-shadow:0 0 0 3px rgba(63,185,80,.18); }
+.live.err .dot { background:var(--bad); box-shadow:0 0 0 3px rgba(248,81,73,.18); }
+select, button { font:inherit; color:var(--fg); background:var(--panel-2);
+  border:1px solid var(--line); border-radius:7px; padding:5px 9px; cursor:pointer; }
+button:hover, select:hover { border-color:var(--faint); }
+button:focus-visible, select:focus-visible { outline:2px solid var(--accent); outline-offset:2px; }
+
+.grid { display:grid; gap:14px; }
+.kpis { grid-template-columns:repeat(4,1fr); margin-bottom:14px; }
+.cards { grid-template-columns:repeat(2,1fr); }
+@media (max-width:860px){ .kpis{ grid-template-columns:repeat(2,1fr);} .cards{ grid-template-columns:1fr;} }
+
+.card { background:var(--panel); border:1px solid var(--line); border-radius:var(--radius); padding:16px; min-width:0; }
+.card h2 { font-size:12px; text-transform:uppercase; letter-spacing:.7px; color:var(--muted);
+  margin:0 0 12px; font-weight:600; }
+
+.kpi .n { font-size:30px; font-weight:680; font-variant-numeric:tabular-nums; letter-spacing:-.5px; }
+.kpi .sub { color:var(--muted); font-size:12px; margin-top:2px; display:flex; align-items:center; gap:6px; }
+.kpi .rate { color:var(--accent); font-family:var(--mono); font-size:11.5px; }
+.kpi.bad .n { color:var(--bad); } .kpi.ok .n { color:var(--ok); }
+.spark { display:block; width:100%; height:34px; margin-top:8px; }
+
+.bars .row { display:grid; grid-template-columns:120px 1fr 52px; align-items:center; gap:10px; margin:7px 0; }
+.bars .lbl { font-size:12.5px; color:var(--fg); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; font-family:var(--mono); }
+.bars .track { background:var(--panel-2); border-radius:5px; height:16px; overflow:hidden; }
+.bars .fill { display:block; height:100%; border-radius:5px; background:var(--accent); transition:width .4s ease; }
+.bars .val { text-align:right; font-variant-numeric:tabular-nums; color:var(--muted); font-size:12.5px; }
+.fill.rule{background:var(--c-rule)} .fill.ip_blacklist{background:var(--c-ip)} .fill.rate_limit{background:var(--c-rate)}
+.fill.country{background:var(--c-country)} .fill.asn{background:var(--c-asn)} .fill.dns_blacklist{background:var(--c-dns)}
+.fill.error,.fill.other{background:var(--c-other)}
+
+table { width:100%; border-collapse:collapse; font-size:12.5px; }
+th { text-align:left; color:var(--muted); font-weight:600; font-size:11px; text-transform:uppercase;
+  letter-spacing:.5px; padding:6px 8px; border-bottom:1px solid var(--line); position:sticky; top:0; background:var(--panel); }
+td { padding:6px 8px; border-bottom:1px solid var(--line); vertical-align:top; }
+tr:last-child td { border-bottom:0; }
+td.mono, .ip { font-family:var(--mono); }
+.path { max-width:280px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--muted); }
+.pill { display:inline-block; padding:1px 7px; border-radius:20px; font-size:11px; font-weight:600;
+  background:var(--panel-2); border:1px solid var(--line); }
+.pill.rule{color:var(--c-rule)} .pill.ip_blacklist{color:var(--c-ip)} .pill.rate_limit{color:var(--c-rate)}
+.pill.country{color:var(--c-country)} .pill.asn{color:var(--c-asn)} .pill.dns_blacklist{color:var(--c-dns)}
+.pill.error,.pill.other{color:var(--muted)}
+.status { font-variant-numeric:tabular-nums; color:var(--warn); }
+.recent-wrap { max-height:420px; overflow:auto; }
+.full { grid-column:1 / -1; }
+
+.empty { color:var(--faint); font-size:13px; padding:14px 2px; text-align:center; }
+.banner { display:none; background:rgba(248,81,73,.12); border:1px solid var(--bad); color:var(--fg);
+  padding:10px 14px; border-radius:8px; margin-bottom:16px; font-size:13px; }
+.banner.show { display:block; }
+footer { margin-top:26px; color:var(--faint); font-size:11.5px; display:flex; gap:14px; flex-wrap:wrap; }
+.flag { font-family:var(--mono); }
+@media (prefers-reduced-motion: reduce){ * { transition:none !important; } }

--- a/ui/dashboard.js
+++ b/ui/dashboard.js
@@ -1,0 +1,160 @@
+/* caddy-waf dashboard — behaviour only, decoupled from markup and styling.
+ *
+ * Modules (no build step, no dependencies):
+ *   config  — runtime config, read from the page (not hard-coded)
+ *   store   — client state: counter history + derived per-minute rates
+ *   fmt     — pure formatting helpers
+ *   charts  — hand-rolled SVG sparklines and CSS bars
+ *   view    — DOM rendering, one function per section
+ *   api     — the metrics source (swappable; the demo replaces just this)
+ *   app     — wiring: poll loop, controls, lifecycle
+ * The data source (api) is isolated so the same view renders live metrics or,
+ * in the docs demo, a generated sample — nothing else changes.
+ */
+(function () {
+  "use strict";
+  const $ = (id) => document.getElementById(id);
+
+  const config = {
+    metricsPath: (document.querySelector('meta[name="waf-metrics-path"]') || {}).content || "",
+    histCap: 180,
+  };
+
+  const store = {
+    hist: [], lastUptime: null,
+    push(m) {
+      if (this.lastUptime != null && m.uptime_seconds != null && m.uptime_seconds < this.lastUptime) this.hist = [];
+      this.lastUptime = m.uptime_seconds;
+      this.hist.push({ t: m.server_time_ms || Date.now(), total: m.total_requests || 0, blocked: m.blocked_requests || 0, allowed: m.allowed_requests || 0 });
+      if (this.hist.length > config.histCap) this.hist.shift();
+    },
+    ratePerMin(key) {
+      const h = this.hist; if (h.length < 2) return null;
+      const dv = h[h.length - 1][key] - h[0][key], dt = (h[h.length - 1].t - h[0].t) / 1000;
+      return dt > 0 && dv >= 0 ? dv / dt * 60 : null;
+    },
+    series(key) {
+      const h = this.hist, out = [];
+      for (let i = 1; i < h.length; i++) { const dv = h[i][key] - h[i - 1][key], dt = (h[i].t - h[i - 1].t) / 1000; out.push(dt > 0 && dv >= 0 ? dv / dt : 0); }
+      return out;
+    },
+  };
+
+  const fmt = {
+    num(n) {
+      if (n == null) return "—"; n = Number(n);
+      if (n >= 1e9) return (n / 1e9).toFixed(2) + "B";
+      if (n >= 1e6) return (n / 1e6).toFixed(2) + "M";
+      if (n >= 1e3) return (n / 1e3).toFixed(1) + "k";
+      return n.toLocaleString();
+    },
+    esc(s) { return String(s == null ? "" : s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c])); },
+    flag(cc) {
+      if (!cc || cc.length !== 2) return ""; const A = 0x1F1E6, up = cc.toUpperCase();
+      return String.fromCodePoint(A + up.charCodeAt(0) - 65) + String.fromCodePoint(A + up.charCodeAt(1) - 65);
+    },
+    uptime(u) { if (u == null) return "uptime —"; const d = Math.floor(u / 86400), h = Math.floor(u % 86400 / 3600), mi = Math.floor(u % 3600 / 60); return "uptime " + (d ? d + "d " : "") + (h || d ? h + "h " : "") + mi + "m"; },
+  };
+
+  const charts = {
+    spark(id, key) {
+      const svg = $(id), vals = store.series(key); svg.innerHTML = "";
+      if (vals.length < 2) return;
+      const W = 100, H = 34, pad = 2, n = vals.length, max = Math.max(1, ...vals);
+      let d = "";
+      for (let i = 0; i < n; i++) { const x = pad + (W - 2 * pad) * (n === 1 ? 0 : i / (n - 1)); const y = H - pad - (H - 2 * pad) * (vals[i] / max); d += (i ? "L" : "M") + x.toFixed(1) + "," + y.toFixed(1) + " "; }
+      const col = getComputedStyle(document.documentElement).getPropertyValue(id.includes("blocked") ? "--bad" : id.includes("allowed") ? "--ok" : "--accent").trim();
+      svg.setAttribute("viewBox", `0 0 ${W} ${H}`);
+      svg.innerHTML = `<path d="${d}L${(W - pad).toFixed(1)},${H - pad} L${pad},${H - pad} Z" fill="${col}" opacity="0.12"/><path d="${d}" fill="none" stroke="${col}" stroke-width="1.6" vector-effect="non-scaling-stroke"/>`;
+    },
+    bars(id, items, { label, value, cls } = {}) {
+      const el = $(id);
+      if (!items || !items.length) { el.innerHTML = '<div class="empty">no data yet</div>'; return; }
+      const max = Math.max(1, ...items.map(value));
+      el.innerHTML = items.map((it) => {
+        const v = value(it), w = Math.max(2, (v / max) * 100), c = cls ? cls(it) : "";
+        return `<div class="row"><span class="lbl" title="${fmt.esc(label(it))}">${fmt.esc(label(it))}</span>` +
+          `<span class="track"><span class="fill ${c}" style="width:${w}%"></span></span>` +
+          `<span class="val">${fmt.num(v)}</span></div>`;
+      }).join("");
+    },
+  };
+
+  const view = {
+    header(m) {
+      $("ver").textContent = m.version || "—";
+      $("uptime").textContent = fmt.uptime(m.uptime_seconds);
+      $("f-schema").textContent = "schema " + (m.schema_version != null ? m.schema_version : "—");
+      $("f-endpoint").textContent = config.metricsPath ? "source " + config.metricsPath : "";
+    },
+    kpis(m) {
+      const total = m.total_requests || 0, blocked = m.blocked_requests || 0;
+      $("k-total").textContent = fmt.num(total);
+      $("k-blocked").textContent = fmt.num(blocked);
+      $("k-allowed").textContent = fmt.num(m.allowed_requests || 0);
+      $("k-ratio").textContent = total ? (blocked / total * 100).toFixed(blocked / total < 0.1 ? 1 : 0) + "%" : "0%";
+      const rt = store.ratePerMin("total"), rb = store.ratePerMin("blocked");
+      $("r-total").textContent = rt == null ? "—" : Math.round(rt);
+      $("r-blocked").textContent = rb == null ? "—" : Math.round(rb);
+      $("s-allowed").textContent = total ? fmt.num(total - blocked) + " passed" : "—";
+      charts.spark("sp-total", "total"); charts.spark("sp-blocked", "blocked"); charts.spark("sp-allowed", "allowed");
+    },
+    breakdowns(m) {
+      const reasons = Object.entries(m.blocked_by_reason || {}).map(([k, v]) => ({ k, v })).filter((x) => x.v > 0).sort((a, b) => b.v - a.v);
+      charts.bars("reasons", reasons, { label: (x) => x.k, value: (x) => x.v, cls: (x) => x.k });
+      const ph = Object.entries(m.rule_hits_by_phase || {}).map(([k, v]) => ({ k: "phase " + k, v })).sort((a, b) => b.v - a.v);
+      charts.bars("phases", ph, { label: (x) => x.k, value: (x) => x.v });
+      charts.bars("rules", (m.top_rules || []).slice(0, 12), { label: (x) => x.id, value: (x) => x.hits });
+      charts.bars("ips", (((m.top_ips || {}).items) || []).slice(0, 12), { label: (x) => x.ip, value: (x) => x.blocked, cls: () => "ip_blacklist" });
+      charts.bars("countries", (m.by_country || []).slice(0, 16), { label: (x) => fmt.flag(x.country) + " " + x.country, value: (x) => x.blocked, cls: () => "country" });
+    },
+    recent(m) {
+      const items = (((m.recent || {}).items) || []), tb = $("recent");
+      if (!items.length) { tb.innerHTML = '<tr><td colspan="8" class="empty">no blocks recorded yet</td></tr>'; return; }
+      tb.innerHTML = items.map((it) => {
+        const t = new Date(it.ts_ms || 0).toLocaleTimeString();
+        const src = `<span class="ip">${fmt.esc(it.ip)}</span>` + (it.country ? ` <span title="${fmt.esc(it.country)}">${fmt.flag(it.country)}</span>` : "");
+        return `<tr><td class="mono">${fmt.esc(t)}</td><td>${src}</td><td class="mono">${fmt.esc(it.method)}</td>` +
+          `<td class="path" title="${fmt.esc(it.path)}">${fmt.esc(it.path)}</td>` +
+          `<td><span class="pill ${fmt.esc(it.reason)}">${fmt.esc(it.reason)}</span></td>` +
+          `<td class="mono">${fmt.esc(it.rule_id || "")}</td><td class="val">${fmt.esc(it.score)}</td>` +
+          `<td class="status">${fmt.esc(it.status)}</td></tr>`;
+      }).join("");
+    },
+    render(m) { this.header(m); this.kpis(m); this.breakdowns(m); this.recent(m); },
+    live(cls, text) { const el = $("live"); el.className = "live " + cls; $("livetext").textContent = text; },
+    banner(msg) { const b = $("banner"); if (!msg) { b.className = "banner"; return; } b.textContent = msg; b.className = "banner show"; },
+  };
+
+  // The only server-coupled module. Returns a metrics object or throws.
+  const api = {
+    async fetchMetrics() {
+      const res = await fetch(config.metricsPath, { headers: { Accept: "application/json" }, cache: "no-store" });
+      if (!res.ok) throw new Error("HTTP " + res.status);
+      return res.json();
+    },
+  };
+
+  const app = {
+    timer: null, interval: 5000, paused: false,
+    async tick() {
+      if (!config.metricsPath) { view.live("err", "no endpoint"); view.banner("Metrics endpoint is not configured. Add `metrics_endpoint /waf_metrics` to the WAF block."); return; }
+      try {
+        const m = await (window.__wafMetricsSource || api.fetchMetrics)();
+        store.push(m); view.render(m); view.banner(""); view.live("on", "live");
+      } catch (e) { view.live("err", "disconnected"); view.banner("Cannot reach " + config.metricsPath + " — " + e.message + ". Showing last data."); }
+    },
+    schedule() { clearInterval(this.timer); if (!this.paused) this.timer = setInterval(() => this.tick(), this.interval); },
+    start() {
+      $("interval").addEventListener("change", (e) => { this.interval = Number(e.target.value) * 1000; this.schedule(); });
+      $("pause").addEventListener("click", (e) => {
+        this.paused = !this.paused; e.target.textContent = this.paused ? "Resume" : "Pause";
+        if (this.paused) { clearInterval(this.timer); view.live("", "paused"); } else { this.tick(); this.schedule(); }
+      });
+      this.tick(); this.schedule();
+    },
+  };
+
+  window.wafDashboard = { store, view, app }; // exposed for the demo to drive
+  app.start();
+})();

--- a/ui/dashboard.js
+++ b/ui/dashboard.js
@@ -59,7 +59,7 @@
   const charts = {
     spark(id, key) {
       const svg = $(id), vals = store.series(key); svg.innerHTML = "";
-      if (vals.length < 2) return;
+      if (vals.length < 1) return;
       const W = 100, H = 34, pad = 2, n = vals.length, max = Math.max(1, ...vals);
       let d = "";
       for (let i = 0; i < n; i++) { const x = pad + (W - 2 * pad) * (n === 1 ? 0 : i / (n - 1)); const y = H - pad - (H - 2 * pad) * (vals[i] / max); d += (i ? "L" : "M") + x.toFixed(1) + "," + y.toFixed(1) + " "; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,92 +3,9 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="waf-metrics-path" content="__WAF_METRICS_PATH__">
 <title>caddy-waf</title>
-<style>
-  :root {
-    --bg: #0f1419; --panel: #161c24; --panel-2: #1b232d; --line: #26313d;
-    --fg: #e6edf3; --muted: #8b98a5; --faint: #5b6875;
-    --accent: #39d3bb; --ok: #3fb950; --warn: #d29922; --bad: #f85149;
-    --chip: #223; --radius: 10px;
-    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  }
-  @media (prefers-color-scheme: light) {
-    :root {
-      --bg:#f5f7fa; --panel:#fff; --panel-2:#f0f3f7; --line:#dde3ea;
-      --fg:#1c2430; --muted:#5b6875; --faint:#93a1af;
-    }
-  }
-  * { box-sizing: border-box; }
-  body { margin:0; background:var(--bg); color:var(--fg); font-family:var(--sans);
-    font-size:14px; line-height:1.45; -webkit-font-smoothing:antialiased; }
-  a { color:var(--accent); }
-  .wrap { max-width:1240px; margin:0 auto; padding:20px 20px 60px; }
-
-  header { display:flex; align-items:center; gap:14px; flex-wrap:wrap;
-    padding-bottom:16px; border-bottom:1px solid var(--line); margin-bottom:20px; }
-  .brand { display:flex; align-items:baseline; gap:10px; }
-  .brand h1 { font-size:18px; margin:0; letter-spacing:.2px; font-weight:650; }
-  .brand .shield { color:var(--accent); font-size:20px; }
-  .ver { font-family:var(--mono); font-size:12px; color:var(--muted);
-    background:var(--panel-2); padding:2px 8px; border-radius:6px; border:1px solid var(--line); }
-  .spacer { flex:1; }
-  .meta { display:flex; align-items:center; gap:16px; color:var(--muted); font-size:12.5px; }
-  .live { display:inline-flex; align-items:center; gap:7px; }
-  .dot { width:8px; height:8px; border-radius:50%; background:var(--faint); transition:background .2s; }
-  .live.on .dot { background:var(--ok); box-shadow:0 0 0 3px rgba(63,185,80,.18); }
-  .live.err .dot { background:var(--bad); box-shadow:0 0 0 3px rgba(248,81,73,.18); }
-  select, button { font:inherit; color:var(--fg); background:var(--panel-2);
-    border:1px solid var(--line); border-radius:7px; padding:5px 9px; cursor:pointer; }
-  button:hover, select:hover { border-color:var(--faint); }
-
-  .grid { display:grid; gap:14px; }
-  .kpis { grid-template-columns:repeat(4,1fr); margin-bottom:14px; }
-  .cards { grid-template-columns:repeat(2,1fr); }
-  @media (max-width:860px){ .kpis{ grid-template-columns:repeat(2,1fr);} .cards{ grid-template-columns:1fr;} }
-
-  .card { background:var(--panel); border:1px solid var(--line); border-radius:var(--radius); padding:16px; min-width:0; }
-  .card h2 { font-size:12px; text-transform:uppercase; letter-spacing:.7px; color:var(--muted);
-    margin:0 0 12px; font-weight:600; }
-
-  .kpi .n { font-size:30px; font-weight:680; font-variant-numeric:tabular-nums; letter-spacing:-.5px; }
-  .kpi .sub { color:var(--muted); font-size:12px; margin-top:2px; display:flex; align-items:center; gap:6px; }
-  .kpi .rate { color:var(--accent); font-family:var(--mono); font-size:11.5px; }
-  .kpi.bad .n { color:var(--bad); } .kpi.ok .n { color:var(--ok); }
-  .spark { display:block; width:100%; height:34px; margin-top:8px; }
-
-  .bars .row { display:grid; grid-template-columns:120px 1fr 52px; align-items:center; gap:10px; margin:7px 0; }
-  .bars .lbl { font-size:12.5px; color:var(--fg); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; font-family:var(--mono); }
-  .bars .track { background:var(--panel-2); border-radius:5px; height:16px; overflow:hidden; }
-  .bars .fill { display:block; height:100%; border-radius:5px; background:var(--accent); transition:width .4s ease; }
-  .bars .val { text-align:right; font-variant-numeric:tabular-nums; color:var(--muted); font-size:12.5px; }
-  .fill.rule{background:#f85149} .fill.ip_blacklist{background:#d29922} .fill.rate_limit{background:#a371f7}
-  .fill.country{background:#58a6ff} .fill.asn{background:#39d3bb} .fill.dns_blacklist{background:#db61a2}
-  .fill.error{background:#8b98a5} .fill.other{background:#6e7681}
-
-  table { width:100%; border-collapse:collapse; font-size:12.5px; }
-  th { text-align:left; color:var(--muted); font-weight:600; font-size:11px; text-transform:uppercase;
-    letter-spacing:.5px; padding:6px 8px; border-bottom:1px solid var(--line); position:sticky; top:0; background:var(--panel); }
-  td { padding:6px 8px; border-bottom:1px solid var(--line); vertical-align:top; }
-  tr:last-child td { border-bottom:0; }
-  td.mono, .ip { font-family:var(--mono); }
-  .path { max-width:280px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--muted); }
-  .pill { display:inline-block; padding:1px 7px; border-radius:20px; font-size:11px; font-weight:600;
-    background:var(--panel-2); border:1px solid var(--line); }
-  .pill.rule{color:#f85149} .pill.ip_blacklist{color:#d29922} .pill.rate_limit{color:#a371f7}
-  .pill.country{color:#58a6ff} .pill.asn{color:#39d3bb} .pill.dns_blacklist{color:#db61a2}
-  .pill.error,.pill.other{color:var(--muted)}
-  .status { font-variant-numeric:tabular-nums; color:var(--warn); }
-  .recent-wrap { max-height:420px; overflow:auto; }
-  .full { grid-column:1 / -1; }
-
-  .empty { color:var(--faint); font-size:13px; padding:14px 2px; text-align:center; }
-  .banner { display:none; background:rgba(248,81,73,.12); border:1px solid var(--bad); color:var(--fg);
-    padding:10px 14px; border-radius:8px; margin-bottom:16px; font-size:13px; }
-  .banner.show { display:block; }
-  footer { margin-top:26px; color:var(--faint); font-size:11.5px; display:flex; gap:14px; flex-wrap:wrap; }
-  .flag { font-family:var(--mono); }
-</style>
+<link rel="stylesheet" href="__BASE__/dashboard.css">
 </head>
 <body>
 <div class="wrap">
@@ -109,7 +26,7 @@
           <option value="30">30s</option>
         </select>
       </label>
-      <button id="pause">Pause</button>
+      <button type="button" id="pause">Pause</button>
       <span class="live" id="live"><span class="dot"></span><span id="livetext">connecting</span></span>
     </div>
   </header>
@@ -154,128 +71,6 @@
     <span class="flag" id="f-endpoint"></span>
   </footer>
 </div>
-
-<script>
-"use strict";
-const METRICS_PATH = "__WAF_METRICS_PATH__";
-const $ = (id) => document.getElementById(id);
-
-const state = { hist: [], timer: null, interval: 5000, paused: false, lastUptime: null };
-const HIST_CAP = 180;
-
-function fmt(n){ if(n==null) return "—"; n=Number(n);
-  if(n>=1e9) return (n/1e9).toFixed(2)+"B"; if(n>=1e6) return (n/1e6).toFixed(2)+"M";
-  if(n>=1e3) return (n/1e3).toFixed(1)+"k"; return n.toLocaleString(); }
-function esc(s){ return String(s==null?"":s).replace(/[&<>"']/g, c=>(
-  {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c])); }
-function flag(cc){ if(!cc||cc.length!==2) return ""; const A=0x1F1E6;
-  return String.fromCodePoint(A+cc.toUpperCase().charCodeAt(0)-65)+String.fromCodePoint(A+cc.toUpperCase().charCodeAt(1)-65); }
-
-function setLive(cls, text){ const el=$("live"); el.className="live "+cls; $("livetext").textContent=text; }
-function banner(msg){ const b=$("banner"); if(!msg){ b.className="banner"; return; } b.textContent=msg; b.className="banner show"; }
-
-// per-minute rate over the recent history window, from monotonic counter deltas.
-function ratePerMin(key){
-  const h=state.hist; if(h.length<2) return null;
-  const a=h[0], b=h[h.length-1];
-  const dv=b[key]-a[key], dt=(b.t-a.t)/1000; // seconds
-  if(dt<=0||dv<0) return null; return dv/dt*60;
-}
-function sparkline(id, key){
-  const svg=$(id); const h=state.hist; svg.innerHTML="";
-  if(h.length<2) return;
-  const W=100,H=34,pad=2; const vals=[];
-  for(let i=1;i<h.length;i++){ const dv=h[i][key]-h[i-1][key], dt=(h[i].t-h[i-1].t)/1000;
-    vals.push(dt>0&&dv>=0?dv/dt:0); }
-  const max=Math.max(1,...vals); const n=vals.length;
-  let d="", area="";
-  for(let i=0;i<n;i++){ const x=pad+(W-2*pad)*(n===1?0:i/(n-1)); const y=H-pad-(H-2*pad)*(vals[i]/max);
-    d+=(i?"L":"M")+x.toFixed(1)+","+y.toFixed(1)+" "; }
-  area=d+`L${(W-pad).toFixed(1)},${H-pad} L${pad},${H-pad} Z`;
-  const col=getComputedStyle(document.documentElement).getPropertyValue(id.includes("blocked")?"--bad":id.includes("allowed")?"--ok":"--accent").trim();
-  svg.setAttribute("viewBox",`0 0 ${W} ${H}`);
-  svg.innerHTML=`<path d="${area}" fill="${col}" opacity="0.12"/><path d="${d}" fill="none" stroke="${col}" stroke-width="1.6" vector-effect="non-scaling-stroke"/>`;
-}
-
-function bars(id, items, {label, value, cls, max}={}){
-  const el=$(id);
-  if(!items||!items.length){ el.innerHTML='<div class="empty">no data yet</div>'; return; }
-  const m=max||Math.max(1,...items.map(value));
-  el.innerHTML=items.map(it=>{ const v=value(it), w=Math.max(2,(v/m)*100), c=cls?cls(it):"";
-    return `<div class="row"><span class="lbl" title="${esc(label(it))}">${esc(label(it))}</span>`+
-      `<span class="track"><span class="fill ${c}" style="width:${w}%"></span></span>`+
-      `<span class="val">${fmt(v)}</span></div>`; }).join("");
-}
-
-function render(m){
-  $("ver").textContent = m.version || "—";
-  $("f-schema").textContent = "schema "+(m.schema_version??"—");
-  $("f-endpoint").textContent = METRICS_PATH ? "source "+METRICS_PATH : "";
-  if(m.uptime_seconds!=null){ const u=m.uptime_seconds;
-    const d=Math.floor(u/86400), h=Math.floor(u%86400/3600), mi=Math.floor(u%3600/60);
-    $("uptime").textContent = "uptime "+(d?d+"d ":"")+(h||d?h+"h ":"")+mi+"m"; }
-
-  const total=m.total_requests||0, blocked=m.blocked_requests||0, allowed=m.allowed_requests||0;
-  $("k-total").textContent=fmt(total);
-  $("k-blocked").textContent=fmt(blocked);
-  $("k-allowed").textContent=fmt(allowed);
-  $("k-ratio").textContent=total?((blocked/total*100).toFixed(blocked/total<0.1?1:0)+"%"):"0%";
-  const rt=ratePerMin("total"), rb=ratePerMin("blocked");
-  $("r-total").textContent=rt==null?"—":Math.round(rt);
-  $("r-blocked").textContent=rb==null?"—":Math.round(rb);
-  $("s-allowed").textContent=total?fmt(total-blocked)+" passed":"—";
-  sparkline("sp-total","total"); sparkline("sp-blocked","blocked"); sparkline("sp-allowed","allowed");
-
-  // reasons
-  const reasons=Object.entries(m.blocked_by_reason||{}).map(([k,v])=>({k,v})).filter(x=>x.v>0).sort((a,b)=>b.v-a.v);
-  bars("reasons", reasons, {label:x=>x.k, value:x=>x.v, cls:x=>x.k});
-  // phases
-  const ph=Object.entries(m.rule_hits_by_phase||{}).map(([k,v])=>({k:"phase "+k,v})).sort((a,b)=>b.v-a.v);
-  bars("phases", ph, {label:x=>x.k, value:x=>x.v});
-  // top rules
-  bars("rules",(m.top_rules||[]).slice(0,12),{label:x=>x.id,value:x=>x.hits});
-  // top ips
-  const ips=((m.top_ips||{}).items)||[];
-  bars("ips", ips.slice(0,12), {label:x=>x.ip, value:x=>x.blocked, cls:()=>"ip_blacklist"});
-  // by country
-  bars("countries",(m.by_country||[]).slice(0,16),{label:x=>flag(x.country)+" "+x.country,value:x=>x.blocked,cls:()=>"country"});
-
-  // recent
-  const items=((m.recent||{}).items)||[];
-  const tb=$("recent");
-  if(!items.length){ tb.innerHTML='<tr><td colspan="8" class="empty">no blocks recorded yet</td></tr>'; }
-  else { tb.innerHTML=items.map(it=>{ const t=new Date(it.ts_ms||0).toLocaleTimeString();
-    const src=`<span class="ip">${esc(it.ip)}</span>`+(it.country?` <span title="${esc(it.country)}">${flag(it.country)}</span>`:"");
-    return `<tr><td class="mono">${esc(t)}</td><td>${src}</td><td class="mono">${esc(it.method)}</td>`+
-      `<td class="path" title="${esc(it.path)}">${esc(it.path)}</td>`+
-      `<td><span class="pill ${esc(it.reason)}">${esc(it.reason)}</span></td>`+
-      `<td class="mono">${esc(it.rule_id||"")}</td><td class="val">${esc(it.score)}</td>`+
-      `<td class="status">${esc(it.status)}</td></tr>`; }).join(""); }
-}
-
-async function tick(){
-  if(!METRICS_PATH){ setLive("err","no endpoint"); banner("Metrics endpoint is not configured. Add `metrics_endpoint /waf_metrics` to the WAF block."); return; }
-  try{
-    const res=await fetch(METRICS_PATH,{headers:{"Accept":"application/json"},cache:"no-store"});
-    if(!res.ok) throw new Error("HTTP "+res.status);
-    const m=await res.json();
-    if(state.lastUptime!=null && m.uptime_seconds!=null && m.uptime_seconds<state.lastUptime){ state.hist=[]; }
-    state.lastUptime=m.uptime_seconds;
-    const t=m.server_time_ms||Date.now();
-    state.hist.push({t, total:m.total_requests||0, blocked:m.blocked_requests||0, allowed:m.allowed_requests||0});
-    if(state.hist.length>HIST_CAP) state.hist.shift();
-    render(m); banner(""); setLive("on","live");
-  }catch(e){ setLive("err","disconnected"); banner("Cannot reach "+METRICS_PATH+" — "+e.message+". Showing last data."); }
-}
-
-function schedule(){ clearInterval(state.timer); if(state.paused) return;
-  state.timer=setInterval(tick, state.interval); }
-
-$("interval").addEventListener("change", e=>{ state.interval=Number(e.target.value)*1000; schedule(); });
-$("pause").addEventListener("click", e=>{ state.paused=!state.paused;
-  e.target.textContent=state.paused?"Resume":"Pause"; if(state.paused){ clearInterval(state.timer); setLive("","paused"); } else { tick(); schedule(); } });
-
-tick(); schedule();
-</script>
+<script src="__BASE__/dashboard.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Refactors the dashboard from one inlined page into **modular, decoupled** files, and makes the theme **automatic**.

## Modular
- `ui/index.html` — **structure only** (config injected via a meta tag + base path).
- `ui/dashboard.css` — **presentation only**.
- `ui/dashboard.js` — **behaviour**, split into decoupled modules: `config` (read from the page, not hard-coded), `store` (history + derived rates), `fmt`, `charts`, `view` (one fn per section), `api` (the *only* server-coupled module), `app`. The data source sits behind `window.__wafMetricsSource`, so the same view renders live metrics **or** a demo sample with nothing else changed — the decoupling made the docs demo a one-line swap.

`dashboard.go` serves `index.html` (templated with base + metrics paths), `dashboard.css` and `dashboard.js` beneath the endpoint, each with its content type; an unknown asset under the path is a 404, not the page. Without `with_ui` the path still returns the build notice.

## Automatic theme
`ui/dashboard.css` uses a three-state token system: a bare `:root` dark palette, `prefers-color-scheme` selecting **light automatically**, and an explicit `data-theme` override winning either way.

## Tests
The `with_ui` test asserts the base/metrics injection into `index.html` and that CSS/JS are served with correct content types. **Verified visually in a browser.** `go test ./...`, `-tags with_ui`, and `-race` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)