### PR TITLE
fix(rules): drop RE2-incompatible auth-session-cookie-not-http-only (#161)

### DIFF
--- a/rules/authentication.json
+++ b/rules/authentication.json
@@ -59,15 +59,5 @@
         "action":"log",
         "score": 3,
         "description":"Log login requests that do not contain login form fields"
-     },
-  {
-     "id":"auth-session-cookie-not-http-only",
-      "phase":2,
-       "pattern":"(?i)(?:session|sid|token|auth)[^;]*?(?<!HttpOnly)(?=[;]|$)",
-      "targets": ["HEADERS:Set-Cookie"],
-      "severity": "MEDIUM",
-       "action": "log",
-      "score": 4,
-     "description": "Log session cookies that are not marked as HttpOnly"
-  }
+     }
 ]

--- a/ssrf_falsepositive_test.go
+++ b/ssrf_falsepositive_test.go
@@ -19,15 +19,16 @@ func loadRuleFile(t *testing.T, path string) []Rule {
 	return rules
 }
 
-// TestBundledRulePatternsCompile guards every shipped rule pattern against RE2
-// breakage -- the whole rules/*.json set plus the combined bundles. RE2 rejects
-// lookbehind/lookahead, so a rule that needs them (as the removed
-// auth-session-cookie-not-http-only did, see #161) fails to load; this catches
-// that class before it ships.
+// TestBundledRulePatternsCompile guards the rule files listed below against RE2
+// breakage: the curated bundles plus the modular files audited for RE2
+// compatibility (rules/ssrf.json, rules/authentication.json). RE2 rejects
+// lookbehind/lookahead and backreferences, so a rule that needs them -- as the
+// removed auth-session-cookie-not-http-only did (see #161) -- fails to load.
+//
+// It is deliberately NOT run over every rules/*.json bundle: several of the
+// other modular files carry invalid JSON or RE2-incompatible patterns, tracked
+// for a full audit in #172. Add a file here once it is clean.
 func TestBundledRulePatternsCompile(t *testing.T) {
-	// The curated bundles plus the modular files audited for RE2 compatibility.
-	// A full rules/*.json audit (some bundles carry invalid JSON or backrefs) is
-	// tracked separately.
 	for _, path := range []string{
 		"rules.json", "rules-browser-friendly.json",
 		"rules/ssrf.json", "rules/authentication.json",

--- a/ssrf_falsepositive_test.go
+++ b/ssrf_falsepositive_test.go
@@ -19,13 +19,19 @@ func loadRuleFile(t *testing.T, path string) []Rule {
 	return rules
 }
 
-// TestBundledRulePatternsCompile guards the patterns in the rule files this
-// change touches against RE2 breakage -- in particular the SSRF pattern edits
-// below. (It is deliberately not run over every rules/*.json bundle: some of
-// those carry patterns that already fail RE2, e.g. the lookbehind in
-// rules/authentication.json, which is a separate pre-existing issue.)
+// TestBundledRulePatternsCompile guards every shipped rule pattern against RE2
+// breakage -- the whole rules/*.json set plus the combined bundles. RE2 rejects
+// lookbehind/lookahead, so a rule that needs them (as the removed
+// auth-session-cookie-not-http-only did, see #161) fails to load; this catches
+// that class before it ships.
 func TestBundledRulePatternsCompile(t *testing.T) {
-	for _, path := range []string{"rules.json", "rules-browser-friendly.json", "rules/ssrf.json"} {
+	// The curated bundles plus the modular files audited for RE2 compatibility.
+	// A full rules/*.json audit (some bundles carry invalid JSON or backrefs) is
+	// tracked separately.
+	for _, path := range []string{
+		"rules.json", "rules-browser-friendly.json",
+		"rules/ssrf.json", "rules/authentication.json",
+	} {
 		for _, r := range loadRuleFile(t, path) {
 			_, err := regexp.Compile(r.Pattern)
 			require.NoErrorf(t, err, "%s: rule %q pattern must compile", path, r.ID)


### PR DESCRIPTION
Fixes #161.

## What
The bundled rule `auth-session-cookie-not-http-only` (`rules/authentication.json`) used a **negative lookbehind + lookahead** (`(?<!HttpOnly)(?=...)`), neither of which Go's **RE2** engine supports — so it **failed to compile and was inert**. It was also mis-specified (it targeted the `Set-Cookie` *response* header in **phase 2**, a request phase, where that header doesn't exist), and "cookie **without** HttpOnly" is an absence check a single RE2 pattern can't express. **Removed.**

The pattern-compile guard now also covers `rules/authentication.json` (now clean), alongside the curated bundles and `rules/ssrf.json`.

## Scope
Extending the guard revealed that **other** modular `rules/*.json` bundles carry invalid JSON (`lfi.json`, `rce.json`) or RE2-incompatible patterns (`hpp.json` backreference, `data-validation.json` oversized repeat). Those are **not** loaded by the default `rules.json` and are a broader cleanup — tracked in #172, not bundled here.

`go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)