### PR TITLE
ci: pin all Actions to commit SHAs; add SBOM + provenance to releases (#117)

### DIFF
--- a/.github/workflows/build-run-validate.yml
+++ b/.github/workflows/build-run-validate.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Dependencies
         run: |
@@ -28,7 +28,7 @@ jobs:
           sudo apt install -y wget git build-essential curl python3 python3-pip
 
       - name: Install Go 1.25
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.25'
             
@@ -72,7 +72,7 @@ jobs:
 
       - name: Cache Python Dependencies
         id: cache-pip
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/pip
           key: pip-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,12 +32,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - name: Build (no push)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           platforms: linux/amd64
@@ -64,12 +64,12 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -79,7 +79,7 @@ jobs:
       # alone would leave anyone who pulled before a security release silently
       # on the old image with no way to name the one they wanted.
       - id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.IMAGE }}
           tags: |
@@ -87,7 +87,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -96,3 +96,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # SLSA provenance + SBOM attestations pushed alongside the image.
+          provenance: mode=max
+          sbom: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,11 +30,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # lastUpdated timestamps come from git history
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
           cache: npm
@@ -43,7 +43,7 @@ jobs:
 
       - run: npm run docs:build
 
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         with:
           path: docs/.vitepress/dist
@@ -60,4 +60,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
             goarch: arm64 # Windows on arm64 is not common, remove it.
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.25' # Use your desired go version
 
@@ -42,7 +42,7 @@ jobs:
           tar czf caddy-waf-${GOOS}-${GOARCH}.tar.gz caddy-waf-${GOOS}-${GOARCH}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: caddy-waf-${{ matrix.goos }}-${{ matrix.goarch }}
           path: caddy-waf-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
@@ -52,9 +52,11 @@ jobs:
     needs: build-and-release # Ensure all builds complete before creating release
     permissions:
       contents: write
+      id-token: write   # mint the provenance attestation
+      attestations: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Extract Tag Name
         id: extract_tag
@@ -62,7 +64,7 @@ jobs:
         run: echo "TAG_NAME=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
 
       - name: Release via GH CLI
         if: startsWith(github.ref, 'refs/tags/')
@@ -78,3 +80,27 @@ jobs:
           # Try to create release with assets. If it fails (exists), upload assets.
           gh release create "$TAG_NAME" *.tar.gz --title "$TAG_NAME" --generate-notes || \
           gh release upload "$TAG_NAME" *.tar.gz --clobber
+
+      # Software Bill of Materials for the release (SPDX), attached as an asset.
+      - name: Generate SBOM
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          format: spdx-json
+          output-file: caddy-waf-sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attach SBOM to the release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.extract_tag.outputs.TAG_NAME }}
+        run: gh release upload "$TAG_NAME" caddy-waf-sbom.spdx.json --clobber
+
+      # SLSA build provenance for the release binaries.
+      - name: Attest build provenance
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: "*.tar.gz"


### PR DESCRIPTION
Supply-chain hardening (#117).

## SHA-pin every Action
All GitHub Actions are pinned to a full commit SHA with the version in a comment, across `build-run-validate`, `docker`, `docs`, `release` (`test.yml` was already pinned). A moved tag can no longer change what runs in CI; Dependabot still bumps them via the version comment. **No floating `@vN` refs remain.**

## SBOM + provenance
- **Container images** — SLSA provenance (`provenance: mode=max`) and an SBOM (`sbom: true`) are pushed as attestations alongside the image.
- **Release binaries** — an SPDX SBOM (`anchore/sbom-action`) is attached to the GitHub release, and a SLSA build-provenance attestation (`actions/attest-build-provenance`) is minted for the `.tar.gz` artifacts (with the `id-token`/`attestations` permissions).

## Validation
The SHA-pins are exercised by this PR's CI (build/test/analyze/docker-build). The release-only SBOM/provenance steps run on the next tag — watched at release time.

Partially addresses #117 (SHA-pin + SBOM/provenance; a full SLSA level + signing policy can follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)