### PR TITLE
test: hot-path benchmarks + CI regression gate (#114)

### DIFF
--- a/.github/bench-gate.py
+++ b/.github/bench-gate.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Fail if any benchmark regressed beyond a threshold.
+
+Usage: bench-gate.py <old.txt> <new.txt>
+Parses `go test -bench` output (multiple -count runs per benchmark), takes the
+median ns/op per benchmark, and exits non-zero if a benchmark present in both
+got slower by more than THRESHOLD. A generous threshold keeps CI-runner noise
+from flapping while still catching real drift.
+"""
+import re
+import statistics
+import sys
+
+THRESHOLD = 1.5  # fail on >50% slower
+
+_LINE = re.compile(r"^(Benchmark\S+?)-\d+\s+\d+\s+([\d.]+)\s+ns/op")
+
+
+def parse(path):
+    runs = {}
+    with open(path) as f:
+        for line in f:
+            m = _LINE.match(line)
+            if m:
+                runs.setdefault(m.group(1), []).append(float(m.group(2)))
+    return {k: statistics.median(v) for k, v in runs.items() if v}
+
+
+def main():
+    old, new = parse(sys.argv[1]), parse(sys.argv[2])
+    if not new:
+        print("No benchmarks found in the current results; nothing to gate.")
+        return 0
+    regressed = []
+    print(f"{'benchmark':40} {'base':>12} {'pr':>12}  ratio")
+    for k in sorted(new):
+        if k in old and old[k] > 0:
+            ratio = new[k] / old[k]
+            flag = "  <-- REGRESSION" if ratio > THRESHOLD else ""
+            print(f"{k:40} {old[k]:12.0f} {new[k]:12.0f}  {ratio:.2f}x{flag}")
+            if ratio > THRESHOLD:
+                regressed.append((k, ratio))
+        else:
+            print(f"{k:40} {'(new)':>12} {new[k]:12.0f}")
+    pct = int((THRESHOLD - 1) * 100)
+    if regressed:
+        print(f"\nFAIL: {len(regressed)} benchmark(s) regressed beyond {pct}%:")
+        for k, r in regressed:
+            print(f"  {k}  {r:.2f}x")
+        return 1
+    print(f"\nOK: no benchmark regressed beyond {pct}%.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,47 @@
+name: Benchmarks
+
+# Hot-path benchmarks with a regression gate, so per-request latency and
+# allocations cannot silently drift. On a PR the current results are compared
+# against the base branch and the job fails on a large regression (#114).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bench-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25'
+
+      - name: Benchmark this ref
+        run: go test -run='^$' -bench=. -benchmem -count=6 ./... | tee new.txt
+
+      - name: Compare against the base branch and gate
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          base="${{ github.base_ref }}"
+          git fetch --quiet origin "$base"
+          if ! git cat-file -e "origin/$base:bench_test.go" 2>/dev/null; then
+            echo "No baseline benchmarks on origin/$base yet — skipping the regression gate."
+            exit 0
+          fi
+          git worktree add --quiet /tmp/base "origin/$base"
+          ( cd /tmp/base && go test -run='^$' -bench=. -benchmem -count=6 ./... ) | tee old.txt
+          python3 .github/bench-gate.py old.txt new.txt

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,105 @@
+package caddywaf
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/phemmer/go-iptrie"
+	"go.uber.org/zap"
+)
+
+// benchMiddleware builds a middleware with the shipped rules.json loaded, so the
+// hot-path benchmarks run against a representative rule set rather than a toy.
+func benchMiddleware(b *testing.B) *Middleware {
+	b.Helper()
+	logger := zap.NewNop()
+	m := &Middleware{
+		logger:                logger,
+		blacklistLoader:       NewBlacklistLoader(logger),
+		AnomalyThreshold:      5,
+		ruleCache:             NewRuleCache(),
+		ipBlacklist:           iptrie.NewTrie(),
+		dnsBlacklist:          map[string]struct{}{},
+		ruleHitsByPhase:       map[int]int64{},
+		RuleFiles:             []string{"rules.json"},
+		requestValueExtractor: NewRequestValueExtractor(logger, false, 0),
+		provisionTime:         time.Now(),
+		topIPsBlocked:         map[string]int64{},
+		blockedByReason:       map[string]int64{},
+		geoIPStats:            map[string]int64{},
+	}
+	if err := m.loadRules(m.RuleFiles); err != nil {
+		b.Fatalf("loadRules: %v", err)
+	}
+	return m
+}
+
+var benchNext = caddyhttp.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) error {
+	w.WriteHeader(http.StatusOK)
+	return nil
+})
+
+// runServeHTTP drives one request per iteration through the full middleware,
+// reporting ns/op and allocs/op. newReq is called each iteration so per-request
+// state (body, context) is fresh, as in production.
+func runServeHTTP(b *testing.B, m *Middleware, newReq func() *http.Request) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.ServeHTTP(httptest.NewRecorder(), newReq(), benchNext) //nolint:errcheck
+	}
+}
+
+// BenchmarkServeHTTP_Benign is the common case: a request that matches nothing
+// and passes through. This is the latency every legitimate request pays.
+func BenchmarkServeHTTP_Benign(b *testing.B) {
+	m := benchMiddleware(b)
+	runServeHTTP(b, m, func() *http.Request {
+		r := httptest.NewRequest(http.MethodGet, testURL+"/products?category=books&page=2", nil)
+		r.RemoteAddr = "203.0.113.5:1234"
+		r.Header.Set("User-Agent", "Mozilla/5.0")
+		return r
+	})
+}
+
+// BenchmarkServeHTTP_Blocked exercises the block path: a request whose query
+// trips the SQLi rules and is refused.
+func BenchmarkServeHTTP_Blocked(b *testing.B) {
+	m := benchMiddleware(b)
+	runServeHTTP(b, m, func() *http.Request {
+		r := httptest.NewRequest(http.MethodGet, testURL+"/items?id=1%20UNION%20SELECT%20password%20FROM%20users", nil)
+		r.RemoteAddr = "203.0.113.9:1234"
+		return r
+	})
+}
+
+// BenchmarkServeHTTP_POSTBody exercises the request-body path (buffering +
+// body-target rules) with a form body.
+func BenchmarkServeHTTP_POSTBody(b *testing.B) {
+	m := benchMiddleware(b)
+	body := strings.Repeat("field=value&", 40)
+	runServeHTTP(b, m, func() *http.Request {
+		r := httptest.NewRequest(http.MethodPost, testURL+"/submit", strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		r.RemoteAddr = "203.0.113.5:1234"
+		return r
+	})
+}
+
+// BenchmarkMetricsScrape measures the /waf_metrics handler (snapshot + marshal),
+// the read path the dashboard polls.
+func BenchmarkMetricsScrape(b *testing.B) {
+	m := benchMiddleware(b)
+	m.MetricsEndpoint = "/waf_metrics"
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r := httptest.NewRequest(http.MethodGet, testURL+"/waf_metrics", nil)
+		r.RemoteAddr = "203.0.113.5:1234"
+		m.ServeHTTP(httptest.NewRecorder(), r, benchNext) //nolint:errcheck
+	}
+}


### PR DESCRIPTION
Establishes per-request latency + allocation benchmarks so performance can't silently drift (#114).

## Benchmarks (`bench_test.go`)
Over the shipped `rules.json` set, covering the hot path:
- `BenchmarkServeHTTP_Benign` — a request that matches nothing (the latency every legit request pays).
- `BenchmarkServeHTTP_Blocked` — a SQLi request that's refused.
- `BenchmarkServeHTTP_POSTBody` — a POST with a form body (buffering + body rules).
- `BenchmarkMetricsScrape` — the `/waf_metrics` read path the dashboard polls.

Each reports ns/op and allocs/op. Local baseline: benign ~130µs/1760 allocs, blocked ~46µs, POST body notably heavier.

## Regression gate (`bench.yml` + `bench-gate.py`)
On a PR the benchmarks are run for the PR **and** the base branch, then compared by median ns/op; the job **fails if any benchmark regressed by more than 50%** — a generous threshold so CI-runner noise doesn't flap while real drift is caught. It **skips gracefully** when the base branch has no benchmarks yet (as here — this PR introduces them).

The harness is the baseline for #115 (rule matching at scale) and #116 (throughput/memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)