### PR TITLE
feat: native Prometheus endpoint + request-duration histogram (#118)

### DIFF
--- a/config.go
+++ b/config.go
@@ -47,6 +47,17 @@ func (cl *ConfigLoader) parseDashboard(d *caddyfile.Dispenser, m *Middleware) er
 	return nil
 }
 
+// parsePrometheusEndpoint parses the prometheus_endpoint directive: the path at
+// which the WAF counters are served in the Prometheus text exposition format.
+func (cl *ConfigLoader) parsePrometheusEndpoint(d *caddyfile.Dispenser, m *Middleware) error {
+	if !d.NextArg() {
+		return d.ArgErr()
+	}
+	m.PrometheusEndpoint = d.Val()
+	cl.logger.Info("Prometheus endpoint configured", zap.String("endpoint", m.PrometheusEndpoint))
+	return nil
+}
+
 // parseLogPath parses the log_path directive.
 func (cl *ConfigLoader) parseLogPath(d *caddyfile.Dispenser, m *Middleware) error {
 	if !d.NextArg() {
@@ -162,6 +173,7 @@ func (cl *ConfigLoader) UnmarshalCaddyfile(d *caddyfile.Dispenser, m *Middleware
 	directiveHandlers := map[string]func(d *caddyfile.Dispenser, m *Middleware) error{
 		"metrics_endpoint":       cl.parseMetricsEndpoint,
 		"dashboard":              cl.parseDashboard,
+		"prometheus_endpoint":    cl.parsePrometheusEndpoint,
 		"log_path":               cl.parseLogPath,
 		"rate_limit":             cl.parseRateLimit,
 		"block_countries":        cl.parseCountryBlockDirective(true),  // Use directive-specific helper
@@ -216,6 +228,9 @@ func (cl *ConfigLoader) parseRuleFile(d *caddyfile.Dispenser, m *Middleware) err
 
 	if m.DashboardEndpoint != "" && !strings.HasPrefix(m.DashboardEndpoint, "/") {
 		return d.Err("dashboard path must start with a leading '/'")
+	}
+	if m.PrometheusEndpoint != "" && !strings.HasPrefix(m.PrometheusEndpoint, "/") {
+		return d.Err("prometheus_endpoint must start with a leading '/'")
 	}
 	if m.MetricsEndpoint != "" && !strings.HasPrefix(m.MetricsEndpoint, "/") {
 		return d.Err("metrics_endpoint must start with a leading '/'")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,7 @@ The full list is the `directiveHandlers` map in [`config.go`](https://github.com
 | Directive | Arguments | Default | Description |
 |---|---|---|---|
 | `metrics_endpoint` | `<path>` | unset | URL path for the JSON metrics document (must start with `/`). When unset, no metrics endpoint is exposed. |
+| `prometheus_endpoint` | `<path>` | unset | URL path serving the WAF counters and a request-duration histogram in the **Prometheus** text exposition format (must start with `/`). Scrape it directly — no exporter needed. See [Prometheus](/prometheus). |
 | `log_path` | `<file>` | `debug.json` (Caddyfile) / `log.json` (Provision fallback) | File path for the JSON log sink. The middleware always writes to stdout in addition. |
 | `log_severity` | `debug` \| `info` \| `warn` \| `error` | `info` | Minimum log level for the WAF logger. |
 | `log_json` | _(no args)_ | off | Enable JSON-formatted logs. Sets the `LogJSON` boolean to `true`. |

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -1,8 +1,31 @@
 # Prometheus and Grafana
 
-The WAF exposes a JSON metrics document at the `metrics_endpoint` path (see [metrics.md](metrics.md)). It does **not** speak the Prometheus exposition format directly. To scrape the metrics with Prometheus, run a small exporter that polls the JSON endpoint and re-publishes the values as Prometheus gauges.
+The WAF speaks Prometheus **natively**. Set `prometheus_endpoint` and Prometheus can scrape it directly — the counters plus a request-duration histogram, in the text exposition format, no exporter needed.
 
-This page describes one such exporter. The same approach generalises to any pull-based metrics system.
+```caddyfile
+waf {
+    rule_file rules.json
+    prometheus_endpoint /metrics
+}
+```
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: caddy-waf
+    static_configs:
+      - targets: ["your-host:port"]
+    metrics_path: /metrics
+```
+
+The series are prefixed `caddywaf_` — `caddywaf_total_requests`, `caddywaf_blocked_requests`, `caddywaf_rule_hits{rule_id=…}`, `caddywaf_blocked_by_reason{reason=…}`, `caddywaf_blocks_by_country{country=…}`, and the `caddywaf_request_duration_seconds` histogram. The counters are **process-local** and reset on restart (use `rate()`/`increase()`, which handle a reset as a counter drop).
+
+> [!TIP]
+> Protect `prometheus_endpoint` the same way as the dashboard and metrics endpoint — it exposes operational detail. Put Caddy `basic_auth`/`forward_auth` in front, or keep it on an internal listener.
+
+## Alternative: a JSON exporter
+
+If you prefer to scrape the [JSON `/waf_metrics`](metrics.md) document instead (for a pull-based setup that already polls JSON), the exporter below polls it and re-publishes the values.
 
 ## A note on counter semantics
 

--- a/handler.go
+++ b/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -21,6 +22,8 @@ type (
 // handler.go
 func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	logID := uuid.New().String()
+	reqStart := time.Now()
+	defer func() { m.observeLatency(time.Since(reqStart).Seconds()) }()
 
 	// Add panic recovery to catch and log panics
 	defer func() {
@@ -97,6 +100,12 @@ func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next cadd
 	//
 	// It sits after Phase 1 and 2 on purpose: the IP blacklist, the rate limiter
 	// and the request rules still apply, so the endpoint can be protected.
+	if m.isPrometheusRequest(r) {
+		m.incrementAllowedRequestsMetric()
+		m.logRequestCompletion(logID, state)
+		return m.handlePrometheusRequest(w, r)
+	}
+
 	if m.isDashboardRequest(r) {
 		m.incrementAllowedRequestsMetric()
 		m.logRequestCompletion(logID, state)

--- a/prometheus.go
+++ b/prometheus.go
@@ -1,0 +1,150 @@
+package caddywaf
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// latencyBounds are the upper edges (seconds) of the request-duration histogram
+// exposed to Prometheus. numLatencyBuckets must equal len(latencyBounds); it is
+// a constant so the per-bucket counters can live in a fixed array on Middleware.
+var latencyBounds = []float64{
+	0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+}
+
+const numLatencyBuckets = 14
+
+// observeLatency records one request duration into the histogram. It runs on the
+// hot path for every request, so it uses atomics and never takes a lock.
+func (m *Middleware) observeLatency(seconds float64) {
+	for i, b := range latencyBounds {
+		if seconds <= b {
+			m.latencyBuckets[i].Add(1)
+			break
+		}
+	}
+	m.latencyCount.Add(1)
+	for {
+		old := m.latencySumBits.Load()
+		nw := math.Float64bits(math.Float64frombits(old) + seconds)
+		if m.latencySumBits.CompareAndSwap(old, nw) {
+			return
+		}
+	}
+}
+
+// isPrometheusRequest reports whether r targets the Prometheus endpoint.
+func (m *Middleware) isPrometheusRequest(r *http.Request) bool {
+	return m.PrometheusEndpoint != "" && r.URL.Path == m.PrometheusEndpoint
+}
+
+// handlePrometheusRequest serves the WAF counters in the Prometheus text
+// exposition format, so Prometheus can scrape natively without the JSON exporter.
+func (m *Middleware) handlePrometheusRequest(w http.ResponseWriter, _ *http.Request) error {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	_, err := w.Write([]byte(m.renderPrometheus()))
+	return err
+}
+
+func (m *Middleware) renderPrometheus() string {
+	var b strings.Builder
+
+	// Base counters, snapshotted under the locks that guard their writers.
+	m.muMetrics.RLock()
+	total, blocked, allowed, geo := m.totalRequests, m.blockedRequests, m.allowedRequests, m.geoIPBlocked
+	m.muMetrics.RUnlock()
+	m.muIPBlacklistMetrics.Lock()
+	ipHits := m.IPBlacklistBlockCount
+	m.muIPBlacklistMetrics.Unlock()
+	m.muDNSBlacklistMetrics.Lock()
+	dnsHits := m.DNSBlacklistBlockCount
+	m.muDNSBlacklistMetrics.Unlock()
+	var rlReq, rlBlocked int64
+	if m.rateLimiter != nil {
+		rlReq, rlBlocked = m.rateLimiter.GetTotalRequests(), m.rateLimiter.GetBlockedRequests()
+	}
+
+	counter := func(name, help string, v int64) {
+		fmt.Fprintf(&b, "# HELP caddywaf_%s %s\n# TYPE caddywaf_%s counter\ncaddywaf_%s %d\n", name, help, name, name, v)
+	}
+	counter("total_requests", "Total requests processed (process-local).", total)
+	counter("blocked_requests", "Total requests blocked (process-local).", blocked)
+	counter("allowed_requests", "Total requests allowed (process-local).", allowed)
+	counter("geoip_blocked", "Requests blocked by country/ASN (process-local).", int64(geo))
+	counter("ip_blacklist_hits", "IP blacklist hits (process-local).", ipHits)
+	counter("dns_blacklist_hits", "DNS blacklist hits (process-local).", dnsHits)
+	counter("rate_limiter_requests", "Requests counted by the rate limiter (process-local).", rlReq)
+	counter("rate_limiter_blocked_requests", "Requests blocked by the rate limiter (process-local).", rlBlocked)
+
+	// Labelled series.
+	writeLabelled(&b, "rule_hits", "Per-rule hit count.", "rule_id", i64map(m.getRuleHitStats()))
+	m.muMetrics.RLock()
+	phases := map[string]int64{}
+	for p, h := range m.ruleHitsByPhase {
+		phases[strconv.Itoa(p)] = h
+	}
+	m.muMetrics.RUnlock()
+	writeLabelled(&b, "rule_hits_by_phase", "Per-phase hit count.", "phase", phases)
+
+	m.muObs.Lock()
+	reasons := map[string]int64{}
+	for k, v := range m.blockedByReason {
+		reasons[k] = v
+	}
+	countries := map[string]int64{}
+	for k, v := range m.geoIPStats {
+		countries[k] = v
+	}
+	m.muObs.Unlock()
+	writeLabelled(&b, "blocked_by_reason", "Blocks by reason category.", "reason", reasons)
+	writeLabelled(&b, "blocks_by_country", "Blocks by ISO country.", "country", countries)
+
+	// Request-duration histogram.
+	fmt.Fprintf(&b, "# HELP caddywaf_request_duration_seconds WAF request handling duration.\n# TYPE caddywaf_request_duration_seconds histogram\n")
+	var cumulative uint64
+	for i, bound := range latencyBounds {
+		cumulative += m.latencyBuckets[i].Load()
+		fmt.Fprintf(&b, "caddywaf_request_duration_seconds_bucket{le=\"%s\"} %d\n", strconv.FormatFloat(bound, 'g', -1, 64), cumulative)
+	}
+	count := m.latencyCount.Load()
+	sum := math.Float64frombits(m.latencySumBits.Load())
+	fmt.Fprintf(&b, "caddywaf_request_duration_seconds_bucket{le=\"+Inf\"} %d\n", count)
+	fmt.Fprintf(&b, "caddywaf_request_duration_seconds_sum %s\n", strconv.FormatFloat(sum, 'g', -1, 64))
+	fmt.Fprintf(&b, "caddywaf_request_duration_seconds_count %d\n", count)
+
+	// Build info.
+	fmt.Fprintf(&b, "# HELP caddywaf_build_info Build information.\n# TYPE caddywaf_build_info gauge\ncaddywaf_build_info{version=\"%s\"} 1\n", promLabel(wafVersion))
+
+	return b.String()
+}
+
+func writeLabelled(b *strings.Builder, name, help, label string, values map[string]int64) {
+	fmt.Fprintf(b, "# HELP caddywaf_%s %s\n# TYPE caddywaf_%s counter\n", name, help, name)
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Fprintf(b, "caddywaf_%s{%s=\"%s\"} %d\n", name, label, promLabel(k), values[k])
+	}
+}
+
+func i64map(m map[string]int) map[string]int64 {
+	out := make(map[string]int64, len(m))
+	for k, v := range m {
+		out[k] = int64(v)
+	}
+	return out
+}
+
+// promLabel escapes a Prometheus label value (backslash, double-quote, newline).
+func promLabel(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return strings.ReplaceAll(s, "\n", `\n`)
+}

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -1,0 +1,89 @@
+package caddywaf
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/phemmer/go-iptrie"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func promMiddleware(t *testing.T) *Middleware {
+	t.Helper()
+	logger := zap.NewNop()
+	return &Middleware{
+		logger:                logger,
+		blacklistLoader:       NewBlacklistLoader(logger),
+		AnomalyThreshold:      5,
+		PrometheusEndpoint:    "/metrics",
+		ruleCache:             NewRuleCache(),
+		ipBlacklist:           iptrie.NewTrie(),
+		dnsBlacklist:          map[string]struct{}{},
+		ruleHitsByPhase:       map[int]int64{},
+		provisionTime:         time.Now(),
+		topIPsBlocked:         map[string]int64{},
+		blockedByReason:       map[string]int64{},
+		geoIPStats:            map[string]int64{},
+		requestValueExtractor: NewRequestValueExtractor(logger, false, 0),
+		Rules: map[int][]Rule{1: {{
+			ID: "block-uri", Pattern: "/blockme", Targets: []string{"URI"},
+			Phase: 1, Score: 10, Action: "block", regex: regexp.MustCompile("/blockme"),
+		}}},
+	}
+}
+
+// TestPrometheusEndpoint pins the native Prometheus exposition (#118): after
+// some traffic, /metrics returns the WAF counters and a request-duration
+// histogram in the text format Prometheus scrapes.
+func TestPrometheusEndpoint(t *testing.T) {
+	m := promMiddleware(t)
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+	send := func(path string) {
+		req := httptest.NewRequest(http.MethodGet, testURL+path, nil)
+		req.RemoteAddr = "203.0.113.5:1234"
+		require.NoError(t, m.ServeHTTP(httptest.NewRecorder(), req, next))
+	}
+	send("/ok")      // allowed
+	send("/ok2")     // allowed
+	send("/blockme") // blocked by the rule
+
+	req := httptest.NewRequest(http.MethodGet, testURL+"/metrics", nil)
+	req.RemoteAddr = "10.0.0.1:1"
+	rec := httptest.NewRecorder()
+	require.NoError(t, m.ServeHTTP(rec, req, next))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Type"), "text/plain; version=0.0.4")
+	body := rec.Body.String()
+
+	for _, want := range []string{
+		"# TYPE caddywaf_total_requests counter",
+		"caddywaf_blocked_requests ",
+		"caddywaf_rule_hits{rule_id=\"block-uri\"} 1",
+		"caddywaf_blocked_by_reason{reason=\"rule\"} 1",
+		"# TYPE caddywaf_request_duration_seconds histogram",
+		"caddywaf_request_duration_seconds_bucket{le=\"+Inf\"}",
+		"caddywaf_request_duration_seconds_count ",
+		"caddywaf_build_info{version=\"" + wafVersion + "\"} 1",
+	} {
+		assert.Containsf(t, body, want, "prometheus output must contain %q", want)
+	}
+
+	// The histogram count must equal the number of requests observed so far
+	// (3 sends + this /metrics scrape counts once the deferred observe runs on a
+	// later request; here at least the 3 sends + the in-flight scrape's own
+	// observe happens after write, so count >= 3).
+	countRe := regexp.MustCompile(`caddywaf_request_duration_seconds_count (\d+)`)
+	m2 := countRe.FindStringSubmatch(body)
+	require.Len(t, m2, 2)
+	assert.GreaterOrEqual(t, m2[1], "3")
+}

--- a/types.go
+++ b/types.go
@@ -3,6 +3,7 @@ package caddywaf
 import (
 	"regexp"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/oschwald/maxminddb-golang"
@@ -187,6 +188,9 @@ type Middleware struct {
 	// tag), serves the built-in read-only dashboard at this path, same-origin
 	// with metrics_endpoint. Opt-in at two levels: build tag + this directive.
 	DashboardEndpoint string `json:"dashboard_endpoint,omitempty"`
+	// PrometheusEndpoint, when set, serves the WAF counters in the Prometheus
+	// text exposition format at this path (native scraping, no exporter needed).
+	PrometheusEndpoint string `json:"prometheus_endpoint,omitempty"`
 
 	configLoader          *ConfigLoader
 	blacklistLoader       *BlacklistLoader
@@ -210,6 +214,11 @@ type Middleware struct {
 	recentBlocks    []blockRecord    // bounded ring, oldest first
 	topIPsBlocked   map[string]int64 // bounded
 	blockedByReason map[string]int64
+
+	// Request-duration histogram (Prometheus), updated lock-free on the hot path.
+	latencyBuckets [numLatencyBuckets]atomic.Uint64
+	latencySumBits atomic.Uint64
+	latencyCount   atomic.Uint64
 
 	rateLimiterBlockedRequests int64        // Add rate limiter blocked requests metric
 	muRateLimiterMetrics       sync.RWMutex // Mutex to protect rate limiter metrics


### PR DESCRIPTION
The WAF exposed metrics only as JSON (docs recommended an external exporter) and tracked no latency. This adds **native Prometheus** and a **duration histogram** (#118).

## `prometheus_endpoint`
Serves the counters in the Prometheus text exposition format — scrapeable directly, no exporter:
```caddyfile
waf { rule_file rules.json; prometheus_endpoint /metrics }
```
Series (`caddywaf_` prefix): `total_requests`, `blocked_requests`, `allowed_requests`, `ip_blacklist_hits`, `dns_blacklist_hits`, `geoip_blocked`, `rate_limiter_*`, `rule_hits{rule_id}`, `rule_hits_by_phase{phase}`, `blocked_by_reason{reason}`, `blocks_by_country{country}`, `build_info{version}`.

## Latency
`caddywaf_request_duration_seconds` histogram. `ServeHTTP` times every request and records it **lock-free** via atomic per-bucket counters — the hot path pays no mutex. Base counters are snapshotted under their existing locks.

## Docs
`prometheus.md` now leads with the native endpoint (+ scrape config + a "protect it" note); the JSON exporter stays as an alternative. `configuration.md` gains the directive.

Test drives traffic → scrapes `/metrics` → asserts the exposition format, counters, labelled series and the histogram. `go test ./...` and `-race` green.

Addresses #118. (Structured block logs already carry rule id / reason / client.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)