### PR TITLE
chore: release v0.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.4.9] - 2026-09-04
+
+### Added
+- **Native Prometheus endpoint** ([#118](https://github.com/fabriziosalmi/caddy-waf/pull/176)). `prometheus_endpoint <path>` serves the WAF counters and a `caddywaf_request_duration_seconds` **latency histogram** in the Prometheus text exposition format — scrape it directly, no exporter. Latency is recorded lock-free on the hot path.
+- **Live dashboard demo** on the docs site (caddy-waf.com/demo), plus the dashboard is now **modular** (structure/style/behaviour split) with an automatic light/dark theme.
+
+### Changed
+- Bumped version constant `wafVersion` to `v0.4.9`.
+- **Supply-chain hardening** ([#117](https://github.com/fabriziosalmi/caddy-waf/pull/174)): every GitHub Action is pinned to a commit SHA; container images carry SLSA provenance + SBOM attestations; release binaries get an SPDX SBOM asset and a build-provenance attestation.
+- **Hot-path benchmarks + CI regression gate** ([#114](https://github.com/fabriziosalmi/caddy-waf/pull/175)): per-request latency/alloc benchmarks now gate PRs against regressions.
+
+### Fixed
+- Removed the inert, RE2-incompatible `auth-session-cookie-not-http-only` rule ([#161](https://github.com/fabriziosalmi/caddy-waf/issues/161)); a broader modular-rules audit is tracked in #172.
+- Updated the hagezi DNS blocklist URL to its new path (community, thanks @mcbloch — [#150](https://github.com/fabriziosalmi/caddy-waf/pull/150)).
+
 ## [v0.4.8] - 2026-09-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Web Application Firewall middleware for the [Caddy](https://caddyserver.com/) 
 
 - **Module ID**: `http.handlers.waf` — [registered in Caddy's package registry](https://caddyserver.com/docs/modules/http.handlers.waf), so the module is selectable on the [download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf)
 - **Go module path**: `github.com/fabriziosalmi/caddy-waf`
-- **Current version**: `v0.4.8` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
+- **Current version**: `v0.4.9` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
 - **License**: AGPL-3.0 — note this is a copyleft licence; check it suits your deployment before integrating
 
 ---
@@ -67,7 +67,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version  {"version":"v0.4.8"}
+INFO  WAF middleware version  {"version":"v0.4.9"}
 INFO  Rate limit configuration  {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded     {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}
@@ -142,11 +142,11 @@ It is also selectable on [caddyserver.com/download](https://caddyserver.com/down
 Images are published to GitHub Container Registry on every release tag, for `linux/amd64` and `linux/arm64`:
 
 ```bash
-docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.8
-docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.8
+docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.9
+docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.9
 ```
 
-Tags are `0.4.8`, `0.4` and `latest` — note there is **no `v` prefix**, unlike the Go module version. Pin an exact version in anything you deploy. See [`docs/docker.md`](docs/docker.md) for volumes, Compose, and hot reload.
+Tags are `0.4.9`, `0.4` and `latest` — note there is **no `v` prefix**, unlike the Go module version. Pin an exact version in anything you deploy. See [`docs/docker.md`](docs/docker.md) for volumes, Compose, and hot reload.
 
 ---
 

--- a/caddywaf.go
+++ b/caddywaf.go
@@ -51,7 +51,7 @@ var (
 )
 
 // Add or update the version constant as needed
-const wafVersion = "v0.4.8" // update this value to the new release version when tagging
+const wafVersion = "v0.4.9" // update this value to the new release version when tagging
 
 // ==================== Initialization and Setup ====================
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     # security fixes, and `latest` leaves no way to name the image you tested
     # against. Swap for `build: .` to run your local checkout instead -- since
     # v0.4.0 that actually compiles the working tree.
-    image: ghcr.io/fabriziosalmi/caddy-waf:0.4.8
+    image: ghcr.io/fabriziosalmi/caddy-waf:0.4.9
     # build: .
     ports:
       - "8080:8080"

--- a/docs/add-package-guide.md
+++ b/docs/add-package-guide.md
@@ -54,7 +54,7 @@ caddy list-modules | grep waf
 ## Pin a version
 
 ```bash
-caddy add-package github.com/fabriziosalmi/caddy-waf@v0.4.8
+caddy add-package github.com/fabriziosalmi/caddy-waf@v0.4.9
 ```
 
 Any tag from the [Releases](https://github.com/fabriziosalmi/caddy-waf/releases)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,16 +7,16 @@ The repository ships a [`Dockerfile`](https://github.com/fabriziosalmi/caddy-waf
 Images are published to GitHub Container Registry on every release tag, for `linux/amd64` and `linux/arm64`:
 
 ```bash
-docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.8
+docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.9
 ```
 
 | Tag | Meaning |
 |---|---|
-| `0.4.8` | An exact release. **Prefer this.** |
+| `0.4.9` | An exact release. **Prefer this.** |
 | `0.4` | Latest patch of the 0.4 line. |
 | `latest` | Latest release, whatever it currently is. |
 
-Note the image tag carries **no `v` prefix**, unlike the Go module version: `caddy add-package …@v0.4.8` but `docker pull …:0.4.8`.
+Note the image tag carries **no `v` prefix**, unlike the Go module version: `caddy add-package …@v0.4.9` but `docker pull …:0.4.9`.
 
 Pin an exact version in anything you deploy. `latest` gives you no way to name the image you tested against, which matters when a release fixes a security defect — see [Security → Advisories](https://github.com/fabriziosalmi/caddy-waf/security/advisories).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ xcaddy build --with github.com/fabriziosalmi/caddy-waf
 Or run the published container image, which needs no Go toolchain:
 
 ```bash
-docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.8
+docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.9
 ```
 
 The module is also selectable on the [Caddy download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf), and `caddy add-package github.com/fabriziosalmi/caddy-waf` works for a one-off install — though Caddy's maintainers have proposed moving that command out of core, so do not build a deployment around it ([#138](https://github.com/fabriziosalmi/caddy-waf/issues/138)).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version          {"version":"v0.4.8"}
+INFO  WAF middleware version          {"version":"v0.4.9"}
 INFO  Rate limit configuration        {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded             {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}
@@ -82,7 +82,7 @@ The module is registered in Caddy's package registry, so an existing Caddy v2.7+
 caddy add-package github.com/fabriziosalmi/caddy-waf
 ```
 
-This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.4.8` if needed.
+This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.4.9` if needed.
 
 The module is also selectable on <https://caddyserver.com/download>.
 
@@ -93,16 +93,16 @@ See [add-package-guide.md](add-package-guide.md) for the full flow, removal, and
 Images are published to GitHub Container Registry on every release tag, for `linux/amd64` and `linux/arm64`. No Go toolchain, no build step:
 
 ```bash
-docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.8
+docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.9
 ```
 
 | Tag | Meaning |
 |---|---|
-| `0.4.8` | An exact release. **Prefer this in deployments.** |
+| `0.4.9` | An exact release. **Prefer this in deployments.** |
 | `0.4` | Latest patch of the 0.4 line. |
 | `latest` | Latest release, whatever it currently is. |
 
-The image tag carries **no `v` prefix**, unlike the Go module version: `@v0.4.8` for `add-package`, `:0.4.8` for `docker pull`.
+The image tag carries **no `v` prefix**, unlike the Go module version: `@v0.4.9` for `add-package`, `:0.4.9` for `docker pull`.
 
 See [docker.md](docker.md) for mounting rule files and blacklists, Docker Compose, and hot reload inside a container.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,7 +41,7 @@ A representative response:
   "dns_blacklist_hits":            0,
   "rate_limiter_requests":         27004,
   "rate_limiter_blocked_requests": 23640,
-  "version":                       "v0.4.8",
+  "version":                       "v0.4.9",
 
   "schema_version":  2,
   "server_time_ms":  1756876543210,


### PR DESCRIPTION
Release prep for **v0.4.9** — the batch since v0.4.8.

## What ships
- **Native Prometheus endpoint + latency histogram** (#118).
- **Supply-chain hardening** — SHA-pinned Actions + SBOM/provenance on images and release binaries (#117).
- **Hot-path benchmarks + CI regression gate** (#114).
- **Live dashboard demo** (caddy-waf.com/demo) + modular UI with automatic light/dark theme.
- **Fixes**: removed the RE2-incompatible auth rule (#161); hagezi DNS blocklist URL (#150, @mcbloch).

## This PR
Bumps `wafVersion` → `v0.4.9`, CHANGELOG entry, version/image-tag references (ghcr `:0.4.9`, no `v` prefix). Historical refs intact.

## After merge
Tagging `v0.4.9` runs `release.yml` (binaries + **SBOM + provenance** — first exercise of the #117 release-time steps) and `docker.yml` (`:0.4.9`, `:0.4`, `:latest`, with image attestations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)