### PR TITLE
test: ReDoS resistance audit + corpus, document the RE2 guarantee (#111)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -144,6 +144,7 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Attack coverage', link: '/attacks' },
+          { text: 'Security posture', link: '/security' },
           { text: 'Testing', link: '/testing' },
           { text: 'Traffic generator', link: '/caddytest' },
           { text: 'Helper scripts', link: '/scripts' },

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,60 @@
+# Security posture
+
+Notes on how the WAF itself resists being turned into a weapon — starting with
+the regex engine, since a rule-driven WAF is an obvious target for a
+regular-expression denial-of-service.
+
+## ReDoS resistance
+
+**caddy-waf is not vulnerable to catastrophic-backtracking ReDoS**, by
+construction.
+
+Every rule pattern is compiled with Go's [`regexp`](https://pkg.go.dev/regexp)
+package, which uses the **RE2** engine. RE2 matches in time **linear in the
+length of the input**, independent of the pattern — it does not backtrack. The
+nested-quantifier constructs that make a pattern explode super-linearly under a
+backtracking engine (PCRE, Oniguruma, JavaScript, Python's `re`) — `(a+)+`,
+`(a|a)*`, `(.*a){n}` — simply run in linear time here. There is **no
+backtracking engine anywhere in the match path**, and no PCRE fallback: both the
+rule matcher and the rate-limiter path regexes go through `regexp`.
+
+This is enforced two ways in the test suite:
+
+- `TestRE2NeutralisesCatastrophicPatterns` compiles textbook "evil regex"
+  patterns and matches them against a 60 KB adversarial input; each must return
+  within a wall-clock budget a backtracking engine would blow past.
+- `TestRuleCorpusIsReDoSResistant` throws a corpus of adversarial inputs (long
+  homogeneous runs with a failing tail, repeated `../`, `%2e`, long query
+  streams, …) at **every shipped rule** — the curated sets and every
+  `rules/*.json` bundle — and asserts each match completes within budget.
+
+Because RE2 is used, a rule author also **cannot** write a backtracking pattern:
+RE2 rejects backreferences and lookaround outright (see
+[the rule bundle notes](https://github.com/fabriziosalmi/caddy-waf/blob/main/rules/README.md)),
+and `TestBundledRulePatternsCompile` fails CI if a shipped bundle contains one.
+
+### Residual cost is linear, and bounded by request size
+
+RE2 removes the *super-linear* risk; what remains is ordinary linear cost. Total
+per-request matching work is roughly **O(input length × rule count)**: a large
+body scanned by many phase-2/3 rules is proportionally more work. This is a
+capacity/tuning concern, not a ReDoS one, and the lever is **request size**:
+
+- **`max_request_body_size`** (default **10 MB**) caps the body handed to the
+  matchers. Lower it if your endpoints never receive large bodies.
+- **`max_response_body_size`** does the same for response-phase rules.
+- Request line and header sizes are bounded by Caddy's HTTP server limits.
+
+A per-match timeout was considered and deliberately **not** added: with RE2 the
+worst case is already linear and the input is already size-bounded, so a timeout
+would add goroutine and cancellation machinery (Go's `regexp` has no native
+deadline) to guard against a blowup that cannot happen. Bounding request size is
+the simpler, sufficient control.
+
+## Related
+
+- [Attack coverage](/attacks) — what the shipped rules detect.
+- [Client IP & trusted proxies](/client-ip) — spoofing boundary for
+  header-derived client IPs.
+- [Security advisories](https://github.com/fabriziosalmi/caddy-waf/security/advisories)
+  — report a vulnerability here.

--- a/redos_test.go
+++ b/redos_test.go
@@ -1,0 +1,119 @@
+package caddywaf
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ReDoS resistance audit (#111).
+//
+// caddy-waf compiles every rule pattern with Go's regexp package, which uses
+// the RE2 engine. RE2 matches in time linear in the length of the input,
+// independent of the pattern: it has no backtracking, so the catastrophic
+// super-linear blowup that powers a classic ReDoS attack cannot occur here.
+// There is no PCRE/backtracking fallback anywhere in the match path
+// (handler.go and ratelimiter.go both call regexp.MatchString).
+//
+// These tests turn that guarantee into an executable, regression-proof check:
+// canonical "evil regex" inputs and long adversarial strings are thrown at both
+// a deliberately pathological pattern and every shipped rule, and each match
+// must complete within a wall-clock budget that a backtracking engine would
+// blow past by orders of magnitude while RE2 stays sub-millisecond.
+//
+// The residual cost is linear: total per-request work is O(input length x rule
+// count), bounded by MaxRequestBodySize (default 10MB) and the server's header
+// limits. That is a capacity concern, not a ReDoS one, and the knob to bound it
+// is request size -- see docs/security.md.
+
+// perMatchBudget is deliberately generous so the test is not flaky on a loaded
+// CI runner, yet still separates RE2 (sub-millisecond here) from a backtracking
+// engine, which on these inputs would take seconds to minutes or never finish.
+const perMatchBudget = 2 * time.Second
+
+// mustMatchWithin runs one regex match and fails if it does not return within
+// perMatchBudget. The match runs in a goroutine so a pathological hang is
+// reported as a test failure instead of wedging the whole run.
+func mustMatchWithin(t *testing.T, re *regexp.Regexp, input, label string) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		_ = re.MatchString(input)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(perMatchBudget):
+		t.Fatalf("%s: match did not complete within %s on a %d-byte input -- possible super-linear pattern", label, perMatchBudget, len(input))
+	}
+}
+
+// redosInputs returns adversarial strings shaped to trigger catastrophic
+// backtracking in an engine that backtracks: long homogeneous runs with a
+// single failing tail, repeated separators, encodings, and long token streams
+// resembling real request values (paths, query strings, cookies).
+func redosInputs() []string {
+	const n = 50000
+	return []string{
+		strings.Repeat("a", n) + "!",
+		strings.Repeat("a", n),
+		strings.Repeat("1", n) + "x",
+		strings.Repeat("/", n),
+		strings.Repeat("../", n/3),
+		strings.Repeat("..\\", n/3),
+		strings.Repeat("%2e", n/3),
+		strings.Repeat("A1", n/2) + "@",
+		strings.Repeat("x=1&", n/4),
+		strings.Repeat(" ", n) + ";",
+		strings.Repeat("<", n),
+		strings.Repeat("'", n),
+		strings.Repeat("http://", n/7),
+		strings.Repeat("\t", n) + "\n",
+	}
+}
+
+// TestRuleCorpusIsReDoSResistant runs the adversarial corpus against every
+// shipped rule's compiled pattern (the curated sets plus every rules/*.json
+// bundle) and asserts each match completes within budget. This proves RE2's
+// linear-time guarantee holds in practice for the real ruleset -- and would
+// catch a future change that somehow introduced a super-linear matcher.
+func TestRuleCorpusIsReDoSResistant(t *testing.T) {
+	bundles, err := filepath.Glob("rules/*.json")
+	require.NoError(t, err)
+	paths := append([]string{"rules.json", "rules-browser-friendly.json"}, bundles...)
+
+	inputs := redosInputs()
+	for _, path := range paths {
+		for _, r := range loadRuleFile(t, path) {
+			re, err := regexp.Compile(r.Pattern)
+			require.NoErrorf(t, err, "%s: rule %q must compile", path, r.ID)
+			for _, in := range inputs {
+				mustMatchWithin(t, re, in, path+" rule "+r.ID)
+			}
+		}
+	}
+}
+
+// TestRE2NeutralisesCatastrophicPatterns documents the guarantee at the engine
+// level: patterns that are textbook ReDoS killers under a backtracking engine
+// -- nested quantifiers over an overlapping class -- run in linear time under
+// RE2. Each is matched against a long failing input and must return promptly.
+func TestRE2NeutralisesCatastrophicPatterns(t *testing.T) {
+	evil := []string{
+		`(a+)+$`,
+		`(a*)*$`,
+		`(a|a)*$`,
+		`(a|aa)+$`,
+		`(.*a){20}$`,
+		`([a-zA-Z]+)*$`,
+	}
+	input := strings.Repeat("a", 60000) + "!" // matches the prefix, fails the anchor
+	for _, pat := range evil {
+		re := regexp.MustCompile(pat)
+		mustMatchWithin(t, re, input, "catastrophic pattern "+pat)
+	}
+}


### PR DESCRIPTION
Closes #111.

## Audit conclusion
**caddy-waf is not vulnerable to catastrophic-backtracking ReDoS, by construction.** Every rule pattern compiles with Go's `regexp` (the **RE2** engine), which matches in time **linear in the input** and **never backtracks**. The nested-quantifier constructs that explode super-linearly under a backtracking engine — `(a+)+`, `(a|a)*`, `(.*a){n}` — run in linear time here. There is **no PCRE/backtracking fallback** in the match path: both `handler.go` and `ratelimiter.go` go through `regexp.MatchString`. RE2 also *rejects* the backreference/lookaround a backtracking-ReDoS pattern needs, already guarded by `TestBundledRulePatternsCompile`.

## What this PR adds
Executable, regression-proof evidence:

- **`TestRE2NeutralisesCatastrophicPatterns`** — textbook "evil regex" patterns matched against a 60 KB adversarial input; each must return within a wall-clock budget (2s) a backtracking engine would blow past by orders of magnitude (RE2 is sub-ms here).
- **`TestRuleCorpusIsReDoSResistant`** — a corpus of adversarial inputs (long homogeneous runs with a failing tail, repeated `../`/`%2e`, long query streams, …) thrown at **every shipped rule** (curated sets + every `rules/*.json` bundle); each match must complete within budget. Proves RE2's linearity on the real ruleset and catches any future super-linear matcher.

## Mitigations evaluated
- **Residual cost is linear**, ~`O(input length × rule count)`, and **bounded** by `max_request_body_size` (default **10 MB**) + server header limits — a capacity/tuning concern, not ReDoS.
- **Per-match timeout: evaluated, deliberately not added.** With RE2 the worst case is already linear and the input already size-bounded; a timeout would add goroutine/cancellation machinery (Go's `regexp` has no native deadline) to guard against a blowup that cannot happen. Bounding request size is the simpler, sufficient control.

## Docs
New **`docs/security.md`** ("Security posture") leads with ReDoS resistance and the size knobs; added to the Reference sidebar.

## Verification
- `go test ./...` green (corpus runs over the whole ruleset in ~4s).
- `npm run docs:check-anchors` ok (22 pages); `docs:build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)