### PR TITLE
fix: fail-safe rule hot-reload + expose geoip_fail_open, document fail-safe behaviour (#113)

### DIFF
--- a/config.go
+++ b/config.go
@@ -179,6 +179,7 @@ func (cl *ConfigLoader) UnmarshalCaddyfile(d *caddyfile.Dispenser, m *Middleware
 		"block_countries":        cl.parseCountryBlockDirective(true),  // Use directive-specific helper
 		"whitelist_countries":    cl.parseCountryBlockDirective(false), // Use directive-specific helper
 		"block_asns":             cl.parseBlockASNsDirective,           // Add ASN block directive
+		"geoip_fail_open":        cl.parseGeoIPFailOpen,
 		"log_severity":           cl.parseLogSeverity,
 		"log_json":               cl.parseLogJSON,
 		"rule_file":              cl.parseRuleFile,
@@ -486,6 +487,30 @@ func (cl *ConfigLoader) parseLogJSON(d *caddyfile.Dispenser, m *Middleware) erro
 func (cl *ConfigLoader) parseRedactSensitiveData(d *caddyfile.Dispenser, m *Middleware) error {
 	m.RedactSensitiveData = true
 	cl.logger.Debug("Redact sensitive data enabled", zap.String("file", d.File()), zap.Int("line", d.Line()))
+	return nil
+}
+
+// parseGeoIPFailOpen enables fail-open GeoIP behaviour. By default a GeoIP
+// lookup error (e.g. a missing database with an enabled country/ASN filter)
+// blocks the request with 403 (fail-closed); with this directive such a request
+// is allowed through instead. It accepts an optional boolean argument
+// (`geoip_fail_open` or `geoip_fail_open true|false|on|off`); a bare directive
+// enables it. Exposed here because the safety knob was previously reachable
+// only through raw JSON (`geoip_fail_open`).
+func (cl *ConfigLoader) parseGeoIPFailOpen(d *caddyfile.Dispenser, m *Middleware) error {
+	value := true
+	if d.NextArg() {
+		switch strings.ToLower(d.Val()) {
+		case "true", "on", "yes", "1":
+			value = true
+		case "false", "off", "no", "0":
+			value = false
+		default:
+			return d.Errf("invalid geoip_fail_open value '%s': expected true/false", d.Val())
+		}
+	}
+	m.GeoIPFailOpen = value
+	cl.logger.Debug("GeoIP fail-open set", zap.Bool("fail_open", value), zap.String("file", d.File()), zap.Int("line", d.Line()))
 	return nil
 }
 

--- a/config.go
+++ b/config.go
@@ -506,7 +506,7 @@ func (cl *ConfigLoader) parseGeoIPFailOpen(d *caddyfile.Dispenser, m *Middleware
 		case "false", "off", "no", "0":
 			value = false
 		default:
-			return d.Errf("invalid geoip_fail_open value '%s': expected true/false", d.Val())
+			return d.Errf("invalid geoip_fail_open value '%s': expected true/false (also accepts on/off, yes/no, 1/0)", d.Val())
 		}
 	}
 	m.GeoIPFailOpen = value

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,7 @@ The full list is the `directiveHandlers` map in [`config.go`](https://github.com
 | `block_countries` | `<mmdb> <ISO> [<ISO> …]` | disabled | Block requests whose source country (per the GeoLite2 Country MMDB) is in the list. |
 | `whitelist_countries` | `<mmdb> <ISO> [<ISO> …]` | disabled | Allow only requests whose source country is in the list. |
 | `block_asns` | `<mmdb> <ASN> [<ASN> …]` | disabled | Block requests whose source IP belongs to one of the listed ASNs. ASN values are decimal integers without a leading `AS`. |
+| `geoip_fail_open` | `[true\|false]` | `false` | When a GeoIP/ASN lookup fails (e.g. missing database), allow the request instead of blocking it with `403`. A bare directive enables it. See [Fail-safe behaviour](/security#request-time). |
 | `custom_response` | `<status> <content-type> <inline-body…>` _or_ `<status> <content-type> <file-path>` | unset | Custom block response. Repeat with different status codes. |
 | `redact_sensitive_data` | _(no args)_ | off | Redact sensitive query parameters and log fields. The redaction key list is in [`logging.go`](https://github.com/fabriziosalmi/caddy-waf/blob/main/logging.go) (`sensitiveKeys`). |
 | `tor` | block (see below) | disabled | Enable Tor exit-node blocking. |

--- a/docs/security.md
+++ b/docs/security.md
@@ -51,6 +51,78 @@ would add goroutine and cancellation machinery (Go's `regexp` has no native
 deadline) to guard against a blowup that cannot happen. Bounding request size is
 the simpler, sufficient control.
 
+## Fail-safe behaviour & secure defaults
+
+What the WAF does when something goes wrong, per feature. "Fail-closed" = the
+request is blocked or the server refuses to start; "fail-open" = the request is
+allowed through.
+
+### Startup (Provision)
+
+Startup is **fail-closed** for anything that would leave the WAF misconfigured:
+
+- **No rule file, or the only rule file is missing / unreadable / invalid JSON /
+  has no valid rules** → Provision returns an error and **Caddy refuses to
+  start**.
+- **A malformed Caddyfile** (unknown directive, bad argument) → startup error.
+- **An unreadable IP-blacklist or DNS-blacklist file**, or **invalid rate-limit
+  config** → startup error.
+
+Two things are tolerated at startup so a single typo doesn't take the server
+down: a **single rule with an uncompilable regex** or an invalid field is
+skipped (logged) and the rest of the file loads; a **malformed line in a
+blacklist file** is skipped. Across *multiple* rule files, a file that fails
+while another still yields rules lets startup proceed with the good ones (logged
+at Error) — so review the logs after a deploy.
+
+A **missing GeoIP database does not block startup**: the country/ASN filter is
+left active but with no reader, which matters at request time — see below.
+
+### Rule hot-reload
+
+Hot-reload is **fail-safe**: if an edited rule file becomes invalid (bad JSON,
+missing, or produces no rules), the reload **fails and the previously loaded
+rules stay in effect** — the WAF is never left running with zero rules by a bad
+edit. The failure is logged; fix the file and save again to reload. (Earlier
+versions replaced the rule set before validating and could drop to zero rules on
+a bad reload; fixed in the #113 audit.)
+
+### Request time
+
+| Feature | On failure | Direction |
+|---|---|---|
+| **Panic** anywhere in request handling | recovered → **500**, request not forwarded upstream | **fail-closed** |
+| **GeoIP / ASN lookup error** (incl. missing DB with the filter enabled) | **403 by default**; allowed only if `geoip_fail_open` is set | **fail-closed by default** |
+| **IP blacklist** — unparseable client IP or uninitialised trie | request allowed | fail-open |
+| **DNS blacklist** — host not in the (static) set | request allowed | fail-open |
+| **Rate limiter** — any non-match / edge | request allowed | fail-open |
+| **Value-extraction error** for one target (non-panic) | that target is skipped, other rules still run | fail-open |
+
+The fail-open cases are inherent to how those checks work — they block only on a
+positive match, so an error or absence means "no match", i.e. allow. The
+fail-closed cases are where an internal error could otherwise let traffic bypass
+a control: a panic yields a 500 rather than a silent pass-through, and a GeoIP
+error blocks by default.
+
+> [!IMPORTANT]
+> If you enable `block_countries` / `whitelist_countries` / `block_asns` but the
+> GeoIP database is missing or unreadable, **every request is blocked with 403**
+> by default (fail-closed). That is deliberate — a country filter that silently
+> stopped filtering would be worse — but if you would rather allow traffic when
+> GeoIP is unavailable, set **`geoip_fail_open`**. Make sure the database path is
+> correct in the first place.
+
+### Secure defaults
+
+| Setting | Default | Notes |
+|---|---|---|
+| Blocking | **on** | The WAF blocks when a request's score reaches `anomaly_threshold` or a matched rule has `mode: block`. There is no global detection-only switch; use per-rule `mode: log` to observe without blocking. |
+| `anomaly_threshold` | **5** (Caddyfile) | Lower = stricter. Raw-JSON configs with the value unset fall back to 20. |
+| `max_request_body_size` | **10 MB** | Caps the body scanned by matchers (see [ReDoS residual cost](#residual-cost-is-linear-and-bounded-by-request-size)). |
+| `max_response_body_size` | **10 MB** | Same, for response-phase rules. |
+| `geoip_fail_open` | **false** (fail-closed) | A GeoIP lookup error blocks unless this is set. |
+| `X-Forwarded-For` trust | **not trusted** | Header-derived client IP is honoured only from configured `trusted_proxies` — see [Client IP](/client-ip). |
+
 ## Related
 
 - [Attack coverage](/attacks) — what the shipped rules detect.

--- a/failsafe_test.go
+++ b/failsafe_test.go
@@ -1,0 +1,119 @@
+package caddywaf
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// Fail-safe behaviour audit (#113).
+
+const validRuleFileJSON = `[
+  {"id":"fs-block-uri","phase":1,"pattern":"/blockme","targets":["URI"],"severity":"HIGH","mode":"block","score":10,"description":"test"}
+]`
+
+func newRuleMiddleware(t *testing.T) *Middleware {
+	t.Helper()
+	return &Middleware{
+		logger:    zap.NewNop(),
+		mu:        sync.RWMutex{},
+		ruleCache: NewRuleCache(),
+	}
+}
+
+func countRules(m *Middleware) int {
+	n := 0
+	for _, rs := range m.Rules {
+		n += len(rs)
+	}
+	return n
+}
+
+// TestReloadKeepsRulesWhenNewFileBecomesInvalid pins the fail-safe fix: a live
+// rule file that is edited into invalid JSON must NOT wipe the in-memory rule
+// set. loadRules previously assigned m.Rules before validating, so a bad reload
+// left the WAF running with zero rules (fail-open). The reload must now fail and
+// keep the previously loaded good rules.
+func TestReloadKeepsRulesWhenNewFileBecomesInvalid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rules.json")
+	require.NoError(t, os.WriteFile(path, []byte(validRuleFileJSON), 0o644))
+
+	m := newRuleMiddleware(t)
+	require.NoError(t, m.loadRules([]string{path}))
+	require.Equal(t, 1, countRules(m), "good rules must load initially")
+
+	// Corrupt the file and reload.
+	require.NoError(t, os.WriteFile(path, []byte("{ this is not valid json"), 0o644))
+	err := m.loadRules([]string{path})
+
+	require.Error(t, err, "a reload from an invalid file must return an error")
+	assert.Equal(t, 1, countRules(m), "the previously loaded rules must be preserved on a failed reload")
+}
+
+// TestReloadKeepsRulesWhenFileDisappears covers the missing-file reload case.
+func TestReloadKeepsRulesWhenFileDisappears(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rules.json")
+	require.NoError(t, os.WriteFile(path, []byte(validRuleFileJSON), 0o644))
+
+	m := newRuleMiddleware(t)
+	require.NoError(t, m.loadRules([]string{path}))
+	require.Equal(t, 1, countRules(m))
+
+	require.NoError(t, os.Remove(path))
+	err := m.loadRules([]string{path})
+
+	require.Error(t, err)
+	assert.Equal(t, 1, countRules(m), "rules must survive a reload of a now-missing file")
+}
+
+// TestInitialLoadStillFailsClosed confirms the fix did not weaken startup: a
+// fresh middleware (no prior rules) pointed at an invalid file still errors, so
+// Provision refuses to start rather than running with zero rules.
+func TestInitialLoadStillFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rules.json")
+	require.NoError(t, os.WriteFile(path, []byte("not json"), 0o644))
+
+	m := newRuleMiddleware(t)
+	err := m.loadRules([]string{path})
+
+	require.Error(t, err, "initial load of an invalid file must fail (fail-closed startup)")
+	assert.Equal(t, 0, countRules(m))
+}
+
+// TestGeoIPFailOpenDirective pins the new Caddyfile directive that exposes the
+// GeoIP fail-open safety knob (previously JSON-only). Default remains
+// fail-closed (false) when the directive is absent.
+func TestGeoIPFailOpenDirective(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		cfg     string
+		want    bool
+		wantErr bool
+	}{
+		{"absent defaults to fail-closed", "waf {\n rule_file rules.json\n}", false, false},
+		{"bare enables fail-open", "waf {\n rule_file rules.json\n geoip_fail_open\n}", true, false},
+		{"explicit true", "waf {\n rule_file rules.json\n geoip_fail_open true\n}", true, false},
+		{"explicit off", "waf {\n rule_file rules.json\n geoip_fail_open off\n}", false, false},
+		{"invalid value errors", "waf {\n rule_file rules.json\n geoip_fail_open maybe\n}", false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Middleware{}
+			err := NewConfigLoader(zap.NewNop()).UnmarshalCaddyfile(caddyfile.NewTestDispenser(tc.cfg), m)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, m.GeoIPFailOpen)
+		})
+	}
+}

--- a/rules.go
+++ b/rules.go
@@ -201,14 +201,30 @@ func (m *Middleware) loadRules(paths []string) error {
 		ruleCounts += fmt.Sprintf("Phase %d: %d rules, ", phase, len(loadedRules[phase]))
 	}
 
-	m.Rules = loadedRules // Atomically update m.Rules after loading all files
-
 	if len(invalidFiles) > 0 {
 		m.logger.Error("Failed to load rule files", zap.Strings("files", invalidFiles)) // Error level for file loading failures
 	}
 	if len(allInvalidRules) > 0 {
 		m.logger.Warn("Validation errors in rules", zap.Strings("errors", allInvalidRules)) // More specific log message - "errors" field
 	}
+
+	// Fail-safe on reload: never degrade a working rule set. If a whole file
+	// failed to load (missing/invalid JSON) or nothing parsed, and we already
+	// hold rules, keep the previous set and surface the error rather than
+	// installing an empty/partial one -- a bad edit to a live rule file must
+	// not silently leave the WAF running with zero (or fewer) rules. At initial
+	// Provision m.Rules is empty, so this guard does not fire and a total
+	// failure still refuses startup (fail-closed) via the same error.
+	prevRuleCount := 0
+	for _, rs := range m.Rules {
+		prevRuleCount += len(rs)
+	}
+	loadFailed := len(invalidFiles) > 0 || (totalRules == 0 && len(paths) > 0)
+	if loadFailed && prevRuleCount > 0 {
+		return fmt.Errorf("rule reload failed (%d invalid file(s), %d rules parsed); keeping %d previously loaded rules", len(invalidFiles), totalRules, prevRuleCount)
+	}
+
+	m.Rules = loadedRules // Atomically update m.Rules only once the load is known good
 
 	if totalRules == 0 && len(paths) > 0 { // Only return error if paths were provided
 		return fmt.Errorf("no valid rules were loaded from any file")


### PR DESCRIPTION
Closes #113.

A per-feature audit of what the WAF does when something fails. Two behaviours were **not** fail-safe — fixed here — and the full matrix is now documented.

## Fixes

**1. Rule hot-reload was fail-open → now fail-safe.**
`loadRules` assigned `m.Rules = loadedRules` *before* validating, so editing a live rule file into invalid JSON (or any state where no rules parse) replaced the in-memory rule set with an **empty map** and only then returned an error — which the file watcher merely logs. The WAF was left **running with zero rules** until the file was fixed. `loadRules` now keeps the previously loaded rules when a reload hard-fails (a whole file missing/invalid, or nothing parsed) and returns the error instead of degrading a working set. Initial Provision is unchanged — with no prior rules the same failure still refuses startup (fail-closed).

**2. `geoip_fail_open` had no Caddyfile directive.** The knob that flips a failed GeoIP lookup from block (403 — the secure default) to allow was reachable only via raw JSON, even though the docs already listed it as a directive. Added `parseGeoIPFailOpen` (bare enables it; accepts `true/false/on/off`).

## Audit conclusions (documented in `docs/security.md`)
Startup is **fail-closed** for anything that leaves the WAF misconfigured (no/invalid sole rule file, malformed Caddyfile, unreadable blacklist files, bad rate-limit config). At request time: a **panic → 500** (not forwarded), and a **GeoIP lookup error → 403 by default**; the IP/DNS blacklists and rate limiter are fail-open by nature (they block only on a positive match). A new secure-defaults table records blocking-on-by-default, `anomaly_threshold` 5, 10 MB body caps, XFF-not-trusted, and the **IMPORTANT** caveat that an enabled country/ASN filter with a missing GeoIP DB blocks all traffic by default.

## Tests
`failsafe_test.go`: reload keeps rules when the file becomes invalid / disappears; initial load still fails closed; `geoip_fail_open` directive parsing (bare / true / off / invalid). Existing reload tests still pass.

## Verification
`go test ./...` green; `npm run docs:check-anchors` ok (22 pages); `docs:build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)