### PR TITLE
chore: release v0.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.4.11] - 2026-09-04
+
+### Security
+- **Path traversal in the request body is now inspected** ([#112](https://github.com/fabriziosalmi/caddy-waf/pull/183)). A new conservative `path-traversal-body` rule catches LFI delivered through a POST body (form fields, JSON) — a repeated `../` or a direct sensitive-file path (`etc/passwd`, `/proc/self/environ`, …) — while a single legitimate `../` in a body does not trip it. The previous `path-traversal` rule covered only the URI and headers.
+- **Rule hot-reload is now fail-safe** ([#113](https://github.com/fabriziosalmi/caddy-waf/pull/182)). A bad edit to a live rule file (invalid JSON, or no rules parsed) no longer wipes the in-memory rule set to empty; the reload fails and the previously loaded rules stay in effect.
+
+### Added
+- **`geoip_fail_open` Caddyfile directive** ([#113](https://github.com/fabriziosalmi/caddy-waf/pull/182)). The knob that flips a failed GeoIP lookup from block (403, the secure default) to allow was previously reachable only through raw JSON.
+- **Security posture docs** ([docs/security.md](https://github.com/fabriziosalmi/caddy-waf/blob/main/docs/security.md)): ReDoS resistance ([#111](https://github.com/fabriziosalmi/caddy-waf/pull/181)), the fail-safe behaviour matrix and secure defaults ([#113](https://github.com/fabriziosalmi/caddy-waf/pull/182)), and evasion coverage ([#112](https://github.com/fabriziosalmi/caddy-waf/pull/183)).
+- **Security regression corpora**: a ReDoS corpus over every shipped rule ([#111](https://github.com/fabriziosalmi/caddy-waf/pull/181)) and an evasion/bypass corpus through the live handler ([#112](https://github.com/fabriziosalmi/caddy-waf/pull/183)).
+
+### Fixed
+- **Modular rule bundles audited** ([#172](https://github.com/fabriziosalmi/caddy-waf/pull/179)): fixed invalid JSON (`lfi.json`, `rfi.json`), rewrote `data-validation`'s over-cap repeat, removed backreference rules (`hpp`, `sql-injection`), and removed the non-functional ModSecurity dump `rules/spiderlabs.json`. `TestBundledRulePatternsCompile` now compiles every `rules/*.json` bundle and rejects duplicate IDs. New `rules/README.md` documents the shipped set vs the opt-in bundle menu.
+
+### Changed
+- Bumped version constant `wafVersion` to `v0.4.11`.
+
 ## [v0.4.10] - 2026-09-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Web Application Firewall middleware for the [Caddy](https://caddyserver.com/) 
 
 - **Module ID**: `http.handlers.waf` — [registered in Caddy's package registry](https://caddyserver.com/docs/modules/http.handlers.waf), so the module is selectable on the [download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf)
 - **Go module path**: `github.com/fabriziosalmi/caddy-waf`
-- **Current version**: `v0.4.10` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
+- **Current version**: `v0.4.11` (see [`caddywaf.go`](caddywaf.go) — `const wafVersion`)
 - **License**: AGPL-3.0 — note this is a copyleft licence; check it suits your deployment before integrating
 
 ---
@@ -67,7 +67,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version  {"version":"v0.4.10"}
+INFO  WAF middleware version  {"version":"v0.4.11"}
 INFO  Rate limit configuration  {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded     {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}
@@ -142,11 +142,11 @@ It is also selectable on [caddyserver.com/download](https://caddyserver.com/down
 Images are published to GitHub Container Registry on every release tag, for `linux/amd64` and `linux/arm64`:
 
 ```bash
-docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.10
-docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.10
+docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.11
+docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.11
 ```
 
-Tags are `0.4.10`, `0.4` and `latest` — note there is **no `v` prefix**, unlike the Go module version. Pin an exact version in anything you deploy. See [`docs/docker.md`](docs/docker.md) for volumes, Compose, and hot reload.
+Tags are `0.4.11`, `0.4` and `latest` — note there is **no `v` prefix**, unlike the Go module version. Pin an exact version in anything you deploy. See [`docs/docker.md`](docs/docker.md) for volumes, Compose, and hot reload.
 
 ---
 

--- a/caddywaf.go
+++ b/caddywaf.go
@@ -51,7 +51,7 @@ var (
 )
 
 // Add or update the version constant as needed
-const wafVersion = "v0.4.10" // update this value to the new release version when tagging
+const wafVersion = "v0.4.11" // update this value to the new release version when tagging
 
 // ==================== Initialization and Setup ====================
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     # security fixes, and `latest` leaves no way to name the image you tested
     # against. Swap for `build: .` to run your local checkout instead -- since
     # v0.4.0 that actually compiles the working tree.
-    image: ghcr.io/fabriziosalmi/caddy-waf:0.4.10
+    image: ghcr.io/fabriziosalmi/caddy-waf:0.4.11
     # build: .
     ports:
       - "8080:8080"

--- a/docs/add-package-guide.md
+++ b/docs/add-package-guide.md
@@ -54,7 +54,7 @@ caddy list-modules | grep waf
 ## Pin a version
 
 ```bash
-caddy add-package github.com/fabriziosalmi/caddy-waf@v0.4.10
+caddy add-package github.com/fabriziosalmi/caddy-waf@v0.4.11
 ```
 
 Any tag from the [Releases](https://github.com/fabriziosalmi/caddy-waf/releases)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,16 +7,16 @@ The repository ships a [`Dockerfile`](https://github.com/fabriziosalmi/caddy-waf
 Images are published to GitHub Container Registry on every release tag, for `linux/amd64` and `linux/arm64`:
 
 ```bash
-docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.10
+docker pull ghcr.io/fabriziosalmi/caddy-waf:0.4.11
 ```
 
 | Tag | Meaning |
 |---|---|
-| `0.4.10` | An exact release. **Prefer this.** |
+| `0.4.11` | An exact release. **Prefer this.** |
 | `0.4` | Latest patch of the 0.4 line. |
 | `latest` | Latest release, whatever it currently is. |
 
-Note the image tag carries **no `v` prefix**, unlike the Go module version: `caddy add-package …@v0.4.10` but `docker pull …:0.4.10`.
+Note the image tag carries **no `v` prefix**, unlike the Go module version: `caddy add-package …@v0.4.11` but `docker pull …:0.4.11`.
 
 Pin an exact version in anything you deploy. `latest` gives you no way to name the image you tested against, which matters when a release fixes a security defect — see [Security → Advisories](https://github.com/fabriziosalmi/caddy-waf/security/advisories).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ xcaddy build --with github.com/fabriziosalmi/caddy-waf
 Or run the published container image, which needs no Go toolchain:
 
 ```bash
-docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.10
+docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.11
 ```
 
 The module is also selectable on the [Caddy download page](https://caddyserver.com/download?package=github.com%2Ffabriziosalmi%2Fcaddy-waf), and `caddy add-package github.com/fabriziosalmi/caddy-waf` works for a one-off install — though Caddy's maintainers have proposed moving that command out of core, so do not build a deployment around it ([#138](https://github.com/fabriziosalmi/caddy-waf/issues/138)).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,7 @@ A representative provisioning log:
 ```
 INFO  Provisioning WAF middleware     {"log_level":"info","log_path":"debug.json","log_json":true,"anomaly_threshold":20}
 INFO  http.handlers.waf  Tor exit nodes updated  {"count":1093}
-INFO  WAF middleware version          {"version":"v0.4.10"}
+INFO  WAF middleware version          {"version":"v0.4.11"}
 INFO  Rate limit configuration        {"requests":100,"window":10,"cleanup_interval":300,"paths":["/api/v1/.*"],"match_all_paths":false}
 WARN  GeoIP database not found. Country blacklisting/whitelisting will be disabled  {"path":"GeoLite2-Country.mmdb"}
 INFO  IP blacklist loaded             {"path":"ip_blacklist.txt","valid_entries":223770,"invalid_entries":0,"total_lines":223770}
@@ -82,7 +82,7 @@ The module is registered in Caddy's package registry, so an existing Caddy v2.7+
 caddy add-package github.com/fabriziosalmi/caddy-waf
 ```
 
-This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.4.10` if needed.
+This asks the Caddy build service for a binary containing your current module set plus `caddy-waf`, then replaces the binary in place (backing up the old one unless `--keep-backup` is passed). Pin a version with `@v0.4.11` if needed.
 
 The module is also selectable on <https://caddyserver.com/download>.
 
@@ -93,16 +93,16 @@ See [add-package-guide.md](add-package-guide.md) for the full flow, removal, and
 Images are published to GitHub Container Registry on every release tag, for `linux/amd64` and `linux/arm64`. No Go toolchain, no build step:
 
 ```bash
-docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.10
+docker run --rm -p 8080:8080 ghcr.io/fabriziosalmi/caddy-waf:0.4.11
 ```
 
 | Tag | Meaning |
 |---|---|
-| `0.4.10` | An exact release. **Prefer this in deployments.** |
+| `0.4.11` | An exact release. **Prefer this in deployments.** |
 | `0.4` | Latest patch of the 0.4 line. |
 | `latest` | Latest release, whatever it currently is. |
 
-The image tag carries **no `v` prefix**, unlike the Go module version: `@v0.4.10` for `add-package`, `:0.4.10` for `docker pull`.
+The image tag carries **no `v` prefix**, unlike the Go module version: `@v0.4.11` for `add-package`, `:0.4.11` for `docker pull`.
 
 See [docker.md](docker.md) for mounting rule files and blacklists, Docker Compose, and hot reload inside a container.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,7 +41,7 @@ A representative response:
   "dns_blacklist_hits":            0,
   "rate_limiter_requests":         27004,
   "rate_limiter_blocked_requests": 23640,
-  "version":                       "v0.4.10",
+  "version":                       "v0.4.11",
 
   "schema_version":  2,
   "server_time_ms":  1756876543210,


### PR DESCRIPTION
Release prep for **v0.4.11** — the security batch since v0.4.10.

## What ships
- **#112** — request-body path traversal is now inspected (`path-traversal-body`), plus a systematic evasion/bypass corpus through the live handler.
- **#113** — rule hot-reload is fail-safe (a bad live edit no longer wipes the rule set); new `geoip_fail_open` Caddyfile directive; fail-safe behaviour + secure-defaults docs.
- **#111** — ReDoS resistance audit (RE2 = linear, no backtracking) + regression corpus over every shipped rule + `docs/security.md`.
- **#172** — modular rule-bundle audit (merged earlier; released here).

## This PR
Bumps `wafVersion` → `v0.4.11`, CHANGELOG entry, version/image-tag references (ghcr `:0.4.11`, no `v` prefix). Historical refs intact.

## After merge
Tagging `v0.4.11` runs `release.yml` (binaries + SBOM + provenance) and `docker.yml` (`:0.4.11`, `:0.4`, `:latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)