### PR TITLE
perf: drop the dead per-rule request-context wrap (#116)

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -576,9 +576,10 @@ func (m *Middleware) handlePhase(w http.ResponseWriter, r *http.Request, phase i
 	for _, rule := range rules {
 		m.logger.Debug("Processing rule", zap.String("rule_id", rule.ID), zap.Int("target_count", len(rule.Targets)))
 
-		// Use the custom type as the key
-		ctx := context.WithValue(r.Context(), ContextKeyRule("rule_id"), rule.ID)
-		r = r.WithContext(ctx)
+		// The rule ID is passed explicitly to every log/block call below via
+		// rule.ID; nothing reads it back out of the request context, so we do not
+		// wrap the request per rule (that cost a Request copy + context node for
+		// every rule on the hot path).
 
 		for _, target := range rule.Targets {
 			m.logger.Debug("Extracting value for target", zap.String("target", target), zap.String("rule_id", rule.ID))

--- a/handler.go
+++ b/handler.go
@@ -61,13 +61,12 @@ func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next cadd
 	// REMOTE_IP rule target all agree on one value.
 	r = r.WithContext(context.WithValue(r.Context(), clientIPKey{}, m.resolveClientIP(r)))
 
-	// Buffer the request body once, up front, when a rule will read it. Rule
-	// extraction runs against per-rule request copies (handlePhase clones the
-	// request via WithContext to tag the rule id), so a body consumed and
-	// "restored" there never reaches the request handed to next -- the upstream
-	// then saw an empty body and every POST with a body failed with a 502.
-	// Capturing it here, on the request that flows downstream, and reading it
-	// from the context during extraction keeps the body intact for the upstream.
+	// Buffer the request body once, up front, when a rule will read it. Reading
+	// r.Body during rule extraction consumes it, so the request handed to next
+	// would see an empty body and every POST with a body failed with a 502
+	// (#156). Capturing it here, on the request that flows downstream, into the
+	// context and reading it from there during extraction keeps the body intact
+	// for the upstream.
 	if m.hasRequestBodyRules() {
 		r = m.captureRequestBody(r)
 	}


### PR DESCRIPTION
Part of #115/#116 hot-path allocation reduction.

## Problem
The rule loop did this on **every rule** (handler.go):
```go
ctx := context.WithValue(r.Context(), ContextKeyRule("rule_id"), rule.ID)
r = r.WithContext(ctx)
```
That's a `http.Request` shallow-copy plus a context node per rule — ~34 per request against the shipped `rules.json`. But **nothing reads that value back**: every log/block call uses `rule.ID` directly, and no code calls `ctx.Value(ContextKeyRule…)`. It was pure overhead.

## Fix
Remove the wrap. Behaviour is identical.

## Measured (median of 6, on top of #188's static dispatch)
| Benchmark | allocs/op | B/op |
|---|---|---|
| ServeHTTP_Benign | 585 → **481** | 67KB → 53KB |
| ServeHTTP_Blocked | 461 → **380** | 50KB → 39KB |

Cumulative from the pre-#115 baseline: 1790 → 481 allocs/op on the benign path (−73%). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)