### PR TITLE
perf: atomic request counters, off the hot-path mutex (#116)

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -73,6 +73,7 @@ func BenchmarkServeHTTP_Benign(b *testing.B) {
 func BenchmarkServeHTTP_BenignParallel(b *testing.B) {
 	m := benchMiddleware(b)
 	b.ReportAllocs()
+	b.ResetTimer() // exclude benchMiddleware() setup, matching the other benchmarks
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			r := httptest.NewRequest(http.MethodGet, testURL+"/products?category=books&page=2", nil)

--- a/bench_test.go
+++ b/bench_test.go
@@ -66,6 +66,23 @@ func BenchmarkServeHTTP_Benign(b *testing.B) {
 	})
 }
 
+// BenchmarkServeHTTP_BenignParallel runs the benign path from many goroutines at
+// once. It is the throughput-under-concurrency measure for #116: it surfaces
+// contention on shared state (the per-request metric counters) that the
+// single-goroutine benchmarks cannot show.
+func BenchmarkServeHTTP_BenignParallel(b *testing.B) {
+	m := benchMiddleware(b)
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r := httptest.NewRequest(http.MethodGet, testURL+"/products?category=books&page=2", nil)
+			r.RemoteAddr = "203.0.113.5:1234"
+			r.Header.Set("User-Agent", "Mozilla/5.0")
+			m.ServeHTTP(httptest.NewRecorder(), r, benchNext) //nolint:errcheck
+		}
+	})
+}
+
 // BenchmarkServeHTTP_Blocked exercises the block path: a request whose query
 // trips the SQLi rules and is refused.
 func BenchmarkServeHTTP_Blocked(b *testing.B) {

--- a/caddywaf.go
+++ b/caddywaf.go
@@ -695,16 +695,13 @@ func (m *Middleware) handleMetricsRequest(w http.ResponseWriter, r *http.Request
 	// Collect rule hits using getRuleHitStats
 	ruleHits := m.getRuleHitStats()
 
-	// Snapshot the shared counters under the locks that guard their writers.
-	//
-	// These used to be read straight off the struct, which raced with every
-	// in-flight request. rule_hits_by_phase made it worse than a benign race:
-	// it is a map, and it was handed to json.Marshal by reference, so the
-	// marshal iterated it while requests wrote to it. Go's runtime answers that
-	// with "concurrent map read and map write" -- a throw, not a data race the
-	// program can shrug off -- which ServeHTTP's panic recovery then turns into
-	// a 500. Scraping metrics under traffic could take out requests, which also
-	// made the endpoint unusable as the source for any dashboard.
+	// Snapshot the shared counters. The scalar counters are atomic, so each is
+	// read with a lock-free Load(). rule_hits_by_phase still needs muMetrics: it
+	// is a map, and it used to be handed to json.Marshal by reference so the
+	// marshal iterated it while requests wrote to it -- Go's runtime answers that
+	// with "concurrent map read and map write", a throw (not a shruggable race)
+	// that ServeHTTP's panic recovery turned into a 500. So the map is copied
+	// under the lock before it leaves this function.
 	totalRequests := m.totalRequests.Load()
 	blockedRequests := m.blockedRequests.Load()
 	allowedRequests := m.allowedRequests.Load()

--- a/caddywaf.go
+++ b/caddywaf.go
@@ -705,11 +705,11 @@ func (m *Middleware) handleMetricsRequest(w http.ResponseWriter, r *http.Request
 	// program can shrug off -- which ServeHTTP's panic recovery then turns into
 	// a 500. Scraping metrics under traffic could take out requests, which also
 	// made the endpoint unusable as the source for any dashboard.
+	totalRequests := m.totalRequests.Load()
+	blockedRequests := m.blockedRequests.Load()
+	allowedRequests := m.allowedRequests.Load()
+	geoIPBlocked := m.geoIPBlocked.Load()
 	m.muMetrics.RLock()
-	totalRequests := m.totalRequests
-	blockedRequests := m.blockedRequests
-	allowedRequests := m.allowedRequests
-	geoIPBlocked := m.geoIPBlocked
 	hitsByPhase := make(map[int]int64, len(m.ruleHitsByPhase))
 	for phase, hits := range m.ruleHitsByPhase {
 		hitsByPhase[phase] = hits

--- a/handler.go
+++ b/handler.go
@@ -192,9 +192,7 @@ func (m *Middleware) logRequestStart(r *http.Request, logID string) {
 
 // incrementTotalRequestsMetric increments the total requests metric.
 func (m *Middleware) incrementTotalRequestsMetric() {
-	m.muMetrics.Lock()
-	m.totalRequests++
-	m.muMetrics.Unlock()
+	m.totalRequests.Add(1)
 }
 
 // initializeWAFState initializes the WAF state.
@@ -305,16 +303,12 @@ func (m *Middleware) handleResponseBodyPhase(recorder *responseRecorder, r *http
 
 // incrementBlockedRequestsMetric increments the blocked requests metric.
 func (m *Middleware) incrementBlockedRequestsMetric() {
-	m.muMetrics.Lock()
-	m.blockedRequests++
-	m.muMetrics.Unlock()
+	m.blockedRequests.Add(1)
 }
 
 // incrementAllowedRequestsMetric increments the allowed requests metric.
 func (m *Middleware) incrementAllowedRequestsMetric() {
-	m.muMetrics.Lock()
-	m.allowedRequests++
-	m.muMetrics.Unlock()
+	m.allowedRequests.Add(1)
 }
 
 // isMetricsRequest checks if it's a metrics request.
@@ -700,9 +694,7 @@ func (m *Middleware) incrementRateLimiterBlockedRequestsMetric() {
 
 // incrementGeoIPRequestsMetric increments the GeoIP requests metric.
 func (m *Middleware) incrementGeoIPRequestsMetric(blocked bool) {
-	m.muMetrics.Lock()
-	defer m.muMetrics.Unlock()
 	if blocked {
-		m.geoIPBlocked++
+		m.geoIPBlocked.Add(1)
 	}
 }

--- a/handler.go
+++ b/handler.go
@@ -692,7 +692,8 @@ func (m *Middleware) incrementRateLimiterBlockedRequestsMetric() {
 	m.rateLimiterBlockedRequests++
 }
 
-// incrementGeoIPRequestsMetric increments the GeoIP requests metric.
+// incrementGeoIPRequestsMetric increments the geoip_blocked counter when the
+// request was blocked by the country/ASN filter (it is a no-op otherwise).
 func (m *Middleware) incrementGeoIPRequestsMetric(blocked bool) {
 	if blocked {
 		m.geoIPBlocked.Add(1)

--- a/prometheus.go
+++ b/prometheus.go
@@ -73,7 +73,7 @@ func (m *Middleware) renderPrometheus() string {
 	counter("total_requests", "Total requests processed (process-local).", total)
 	counter("blocked_requests", "Total requests blocked (process-local).", blocked)
 	counter("allowed_requests", "Total requests allowed (process-local).", allowed)
-	counter("geoip_blocked", "Requests blocked by country/ASN (process-local).", int64(geo))
+	counter("geoip_blocked", "Requests blocked by country/ASN (process-local).", geo)
 	counter("ip_blacklist_hits", "IP blacklist hits (process-local).", ipHits)
 	counter("dns_blacklist_hits", "DNS blacklist hits (process-local).", dnsHits)
 	counter("rate_limiter_requests", "Requests counted by the rate limiter (process-local).", rlReq)

--- a/prometheus.go
+++ b/prometheus.go
@@ -53,10 +53,9 @@ func (m *Middleware) handlePrometheusRequest(w http.ResponseWriter, _ *http.Requ
 func (m *Middleware) renderPrometheus() string {
 	var b strings.Builder
 
-	// Base counters, snapshotted under the locks that guard their writers.
-	m.muMetrics.RLock()
-	total, blocked, allowed, geo := m.totalRequests, m.blockedRequests, m.allowedRequests, m.geoIPBlocked
-	m.muMetrics.RUnlock()
+	// Base counters are atomic; read each independently (metrics don't need a
+	// cross-counter-consistent snapshot).
+	total, blocked, allowed, geo := m.totalRequests.Load(), m.blockedRequests.Load(), m.allowedRequests.Load(), m.geoIPBlocked.Load()
 	m.muIPBlacklistMetrics.Lock()
 	ipHits := m.IPBlacklistBlockCount
 	m.muIPBlacklistMetrics.Unlock()

--- a/types.go
+++ b/types.go
@@ -200,12 +200,15 @@ type Middleware struct {
 	RateLimit   RateLimit
 	rateLimiter *RateLimiter
 
-	totalRequests   int64
-	blockedRequests int64
-	allowedRequests int64
+	// Process-local request counters, incremented on every request. Atomic so
+	// the hot path takes no lock for them (#116) -- muMetrics now guards only the
+	// ruleHitsByPhase map below.
+	totalRequests   atomic.Int64
+	blockedRequests atomic.Int64
+	allowedRequests atomic.Int64
 	ruleHitsByPhase map[int]int64
 	geoIPStats      map[string]int64 // Key: country code, Value: count
-	muMetrics       sync.RWMutex     // Mutex for metrics synchronization
+	muMetrics       sync.RWMutex     // Guards the ruleHitsByPhase map
 
 	// Observability for the built-in dashboard (#143 M1). geoIPStats above holds
 	// per-country BLOCK counts; the fields below and it are all guarded by muObs.
@@ -223,7 +226,7 @@ type Middleware struct {
 	rateLimiterBlockedRequests int64        // Add rate limiter blocked requests metric
 	muRateLimiterMetrics       sync.RWMutex // Mutex to protect rate limiter metrics
 
-	geoIPBlocked int
+	geoIPBlocked atomic.Int64
 
 	Tor TorConfig `json:"tor,omitempty"`
 


### PR DESCRIPTION
Part of #116 (throughput under concurrent load).

## Problem
`totalRequests`/`blockedRequests`/`allowedRequests`/`geoIPBlocked` were plain integers guarded by the single `muMetrics` mutex, incremented on **every** request — so a benign request took that one global write lock ~3–5 times just to bump counters. Under concurrent load that lock is a contention point, and it also contends with the metrics/prometheus readers.

## Fix
Made them `atomic.Int64`; removed the lock from the increment and read paths. `muMetrics` now guards **only** the `ruleHitsByPhase` map (touched per rule-hit, not per request). Metric reads `Load()` each counter independently — fine for process-local counters (no need for a cross-counter-consistent snapshot).

Adds **`BenchmarkServeHTTP_BenignParallel`** (`b.RunParallel`) — the throughput-under-concurrency measure #116 was missing.

## Honest results
The win is **modest at 8 cores** (~25µs → ~24µs; the critical section was tiny) and grows with core count — production servers with 16–64 cores contend harder on a per-request global lock. The primary value is that the lock is simply **gone from the hot path**, and the metrics readers no longer fight the request path.

`go test -race` clean; full suite green. Allocations unchanged (atomics don't allocate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)