### PR TITLE
perf: fast path in compressWhitespace (#115)

### DIFF
--- a/transform.go
+++ b/transform.go
@@ -111,6 +111,25 @@ func removeNulls(s string) string {
 // compressWhitespace folds any run of ASCII whitespace to a single space,
 // defeating tab/newline substitution for the space in payloads.
 func compressWhitespace(s string) string {
+	// Fast path: return the input unchanged (no allocation) when nothing would
+	// be folded -- no non-space whitespace and no run of two whitespace chars.
+	// This is the common case on the hot path (a query value like "books"), and
+	// the builder below otherwise allocates a fresh string on every call.
+	needs := false
+	prevWS := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		ws := c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\v' || c == '\f'
+		if ws && (c != ' ' || prevWS) {
+			needs = true
+			break
+		}
+		prevWS = ws
+	}
+	if !needs {
+		return s
+	}
+
 	var b strings.Builder
 	b.Grow(len(s))
 	inWS := false

--- a/transform_test.go
+++ b/transform_test.go
@@ -46,6 +46,12 @@ func TestOtherTransforms(t *testing.T) {
 	if got := compressWhitespace("  a  b  "); got != " a b " {
 		t.Errorf("compressWhitespace runs: %q", got)
 	}
+	// The fast path is the point of the change: an input that needs no folding
+	// must not allocate. Guard it so a future edit that reintroduces the builder
+	// allocation on this path is caught.
+	if allocs := testing.AllocsPerRun(100, func() { _ = compressWhitespace("no-folding-needed") }); allocs != 0 {
+		t.Errorf("compressWhitespace fast path allocated %v times, want 0", allocs)
+	}
 	if got := replaceComments("un/**/ion/*x*/sel"); got != "un ion sel" {
 		t.Errorf("replaceComments: %q", got)
 	}

--- a/transform_test.go
+++ b/transform_test.go
@@ -36,6 +36,16 @@ func TestOtherTransforms(t *testing.T) {
 	if got := compressWhitespace("union\t\n  select"); got != "union select" {
 		t.Errorf("compressWhitespace: %q", got)
 	}
+	// Fast path: inputs that need no folding must come back unchanged.
+	for _, s := range []string{"", "books", "a b c", "one two three"} {
+		if got := compressWhitespace(s); got != s {
+			t.Errorf("compressWhitespace(%q) fast path: got %q", s, got)
+		}
+	}
+	// Leading/trailing and run folding still work.
+	if got := compressWhitespace("  a  b  "); got != " a b " {
+		t.Errorf("compressWhitespace runs: %q", got)
+	}
 	if got := replaceComments("un/**/ion/*x*/sel"); got != "un ion sel" {
 		t.Errorf("replaceComments: %q", got)
 	}


### PR DESCRIPTION
Small hot-path allocation fix (part of #115).

`compressWhitespace` always built a fresh string via `strings.Builder`, even when the input had no non-space whitespace and no run of two whitespace chars — the common case (a query value like `books`). The default transform chain folds whitespace for **every raw target**, so that was a wasted string allocation per target. Added a scan that returns the input unchanged when nothing would be folded.

Measured (median of 6): `ServeHTTP_Benign` 347 → **331** allocs/op, `ServeHTTP_Blocked` 285 → **276**. The transform test now pins both the fast path (unchanged inputs) and the folding path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)