### PR TITLE
Link the privacy notice from the docs footer

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -162,7 +162,13 @@ export default defineConfig({
     outline: { level: [2, 3] },
 
     footer: {
-      message: `Released under the AGPL-3.0 licence. <a href="${repo}/security/advisories">Security advisories</a>.`,
+      // The privacy notice lives once, at fabriziosalmi.github.io/privacy, and
+      // is shared by every project site published from this account — same
+      // publisher, same GitHub Pages hosting, same absence of analytics,
+      // cookies and forms. A copy here would start drifting from it the day it
+      // was written, which is the reason there is one document rather than
+      // thirty.
+      message: `Released under the AGPL-3.0 licence. <a href="${repo}/security/advisories">Security advisories</a>. <a href="https://fabriziosalmi.github.io/privacy">Privacy &amp; legal</a>.`,
       copyright: `Copyright © ${new Date().getFullYear()} Fabrizio Salmi`,
     },
   },


### PR DESCRIPTION
`www.caddy-waf.com` serves no privacy notice at all. It needs one: the page is delivered by GitHub Pages, which receives the visitor's IP address and user-agent, so a processor outside the EEA is involved before anyone has read a word. Art. 13 applies to a static documentation site like any other.

**Why a link rather than a page**

Every project site published from this account is the same thing — same publisher, same hosting, same absence of analytics, cookies, forms and accounts. Thirty copies of one document is thirty documents drifting apart, which is why the shared notice at `fabriziosalmi.github.io/privacy` exists and why 32 sites already point at it.

**Depends on:** fabriziosalmi/fabriziosalmi.github.io#5, which widens that notice's scope to cover sites answering on their own domain. Merge that one first, or this links a page that says it does not describe this site.

**Verified:** `npx vitepress build docs` succeeds and the link is present in the rendered footer of the generated site.

Found while measuring the estate with privacymate: `PM-DOC-01`, no privacy notice reachable from the public page. I will re-scan the live site after this deploys and report whether the finding actually closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)