### PR TITLE
fix(engine): read rule action from the "action" JSON key, not "mode" (audit 1/5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **The rule `action` field was never read.** `Rule.Action` was tagged `json:"mode"`, but every shipped rule file (and the documentation) keys it `"action"`, so `Action` unmarshalled to the empty string for every rule. In practice `action: "block"` never triggered an explicit block: all blocking happened only when accumulated scores crossed `anomaly_threshold`, and the `log`-vs-`block` distinction did not exist at runtime. The tag is now `json:"action"`, and `mode` is still accepted as an alias (with `action` winning when both are present) so rule files written against the earlier documentation, which named the key `mode`, keep working. `docs/rules.md` now documents `action` as the canonical key. Two consequences worth knowing when upgrading: (1) a `block` rule now blocks on its first match regardless of score, which matters if your `anomaly_threshold` is higher than a rule's score (no rule shipped in `rules.json` or the `rules/` bundles is scored below the Caddyfile default of 5, but the JSON-config fallback threshold is 20, and 23 `rules.json` block rules score below that); (2) the load-time validation that only accepts `block` or `log` is now effective, so a custom rule with any other `action` value fails to load instead of silently running as a score-only rule. `rule_action_test.go` pins both the unmarshalling and the runtime effect.
+
 ## [v0.4.13] - 2026-09-04
 
 ### Changed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,9 +47,9 @@ Within each phase the runtime iterates over the rules already sorted by descendi
    - The rule's `score` is added to `state.TotalScore`.
    - The request is **blocked** if either of the following is true:
      - `state.TotalScore >= anomaly_threshold`
-     - the rule's `mode` field equals `"block"`
+     - the rule's `action` field equals `"block"`
    - When blocked, `403 Forbidden` is written (or the configured custom response for that status code), and rule processing stops for that phase.
-   - When the rule's `mode` is `"log"` and neither condition above is true, processing continues with the next target/rule.
+   - When the rule's `action` is `"log"` and neither condition above is true, processing continues with the next target/rule.
 
 ### Blocking precedence summary
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -18,7 +18,7 @@ If the configured `metrics_endpoint` matches the request path, the middleware se
 
 ## Capabilities at a glance
 
-- Regex rules with phases, severity, score, and explicit `mode` (`block` or `log`).
+- Regex rules with phases, severity, score, and explicit `action` (`block` or `log`).
 - Anomaly scoring: rule scores accumulate; the request is blocked when `anomaly_threshold` is reached.
 - IP blacklist (single addresses and CIDR ranges, IPv4 and IPv6) backed by a prefix trie.
 - DNS blacklist with exact (case-insensitive) host matching.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -16,7 +16,7 @@ The schema below mirrors the `Rule` struct in [`types.go`](https://github.com/fa
   "targets":     ["URI", "ARGS"],
   "severity":    "HIGH",
   "score":       8,
-  "mode":        "block",
+  "action":      "block",
   "description": "Human-readable description",
   "priority":    10
 }
@@ -31,7 +31,7 @@ The schema below mirrors the `Rule` struct in [`types.go`](https://github.com/fa
 | Transformations | `transformations` | array of string | no | Optional per-rule input transformation pipeline (ModSecurity/CRS names, e.g. `["urlDecodeUni","removeNulls"]`). See [Input normalization](#input-normalization). Absent = the per-target default chain; explicit `[]` = no transformation. |
 | Severity | `severity` | string | no | Free-form label used only for logging (e.g. `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`). It does **not** affect blocking decisions. |
 | Score | `score` | int | yes (validated ≥ 0) | Added to the request's anomaly score on match. |
-| Mode | `mode` | string | no | `"block"` (block immediately on match) or `"log"` (log and continue). Empty / missing means: rely on the anomaly threshold only. The Go field is `Action` but the JSON tag is `mode` — see [Field name caveat](#field-name-caveat). |
+| Action | `action` | string | no | `"block"` (block immediately on match) or `"log"` (log and continue). Empty / missing means: rely on the anomaly threshold only. `mode` is accepted as an alias for files written against older documentation — see [Field name caveat](#field-name-caveat). |
 | Description | `description` | string | no | Human-readable description, written to log records. |
 | Priority | `priority` | int | no | Higher priority is evaluated first within a phase. Defaults to `0`. |
 
@@ -44,17 +44,15 @@ A rule is rejected (and dropped from the runtime ruleset, with a warning logged)
 - `targets` is empty
 - `phase` is outside `[1, 4]`
 - `score` is negative
-- `mode` is non-empty and not equal to `"block"` or `"log"`
+- `action` is non-empty and not equal to `"block"` or `"log"`
 
 Loading a file is aborted only when the file cannot be read or its contents cannot be parsed as a JSON array of rules. Individual invalid rules do not abort the load; they are reported in the `Validation errors in rules` log entry.
 
 ### Field name caveat
 
-The Go struct declares the action as `Action string \`json:"mode"\`` ([`types.go`](https://github.com/fabriziosalmi/caddy-waf/blob/main/types.go) line 79). This means the JSON property name read by the loader is **`mode`**, not `action`. Files that use `"action"` will be parsed (the field is simply absent from the rule), and the rule will not have an explicit block — it will rely entirely on the cumulative anomaly score reaching `anomaly_threshold`.
+The JSON key for the action is **`action`**, matching the Go field `Action` ([`types.go`](https://github.com/fabriziosalmi/caddy-waf/blob/main/types.go)). Every bundled rule file uses it.
 
-The bundled [`rules.json`](https://github.com/fabriziosalmi/caddy-waf/blob/main/rules.json) currently uses `"action"`; the bundled [`sample_rules.json`](https://github.com/fabriziosalmi/caddy-waf/blob/main/sample_rules.json) uses `"mode"`. Files under [`rules/`](https://github.com/fabriziosalmi/caddy-waf/tree/main/rules) use `"action"` and therefore behave as if no explicit block were set.
-
-When authoring new rules, prefer `"mode"`.
+Earlier versions of this page documented the key as `mode` because the Go struct was tagged `json:"mode"` while the bundled files used `"action"` — so, in practice, no shipped rule ever had an explicit action and all blocking came from the anomaly threshold. That tag is fixed. To keep rule files written against the old documentation working, the loader still accepts `mode` as an alias; when both keys are present, `action` wins. When authoring new rules, use `"action"`.
 
 ---
 
@@ -216,7 +214,7 @@ Rules with `mode == "log"` log the match at INFO level and let evaluation contin
     "targets": ["HEADERS:User-Agent"],
     "severity": "CRITICAL",
     "score": 10,
-    "mode": "block",
+    "action": "block",
     "priority": 100,
     "description": "Block well-known vulnerability scanners by User-Agent."
   },
@@ -227,7 +225,7 @@ Rules with `mode == "log"` log the match at INFO level and let evaluation contin
     "targets": ["BODY", "ARGS", "URI", "HEADERS"],
     "severity": "CRITICAL",
     "score": 10,
-    "mode": "block",
+    "action": "block",
     "description": "Detect Log4Shell (CVE-2021-44228) JNDI injection attempts."
   },
   {
@@ -237,7 +235,7 @@ Rules with `mode == "log"` log the match at INFO level and let evaluation contin
     "targets": ["BODY"],
     "severity": "LOW",
     "score": 1,
-    "mode": "log",
+    "action": "log",
     "description": "Record suspicious keyword without blocking."
   },
   {
@@ -247,7 +245,7 @@ Rules with `mode == "log"` log the match at INFO level and let evaluation contin
     "targets": ["JSON_PATH:user.is_admin"],
     "severity": "HIGH",
     "score": 8,
-    "mode": "block",
+    "action": "block",
     "description": "Block requests attempting to set is_admin via mass assignment."
   },
   {
@@ -257,7 +255,7 @@ Rules with `mode == "log"` log the match at INFO level and let evaluation contin
     "targets": ["RESPONSE_HEADERS:Server"],
     "severity": "MEDIUM",
     "score": 2,
-    "mode": "log",
+    "action": "log",
     "description": "Log responses leaking the server software identity."
   }
 ]

--- a/rule_action_test.go
+++ b/rule_action_test.go
@@ -1,0 +1,112 @@
+package caddywaf
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/phemmer/go-iptrie"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// TestRuleActionUnmarshalsFromJSON pins the fix for the json:"mode" tag bug:
+// the shipped rule files key the action as "action", so a rule loaded from
+// JSON must have Action populated. Before the fix every rule unmarshalled to
+// Action=="" — action:"block" never triggered an explicit block, and the
+// log-vs-block distinction did not exist at runtime. This test loads the real
+// rules.json and asserts both actions are present, so the tag cannot silently
+// regress. The Go tests did not catch the original bug because they set
+// Action directly on the struct, bypassing JSON.
+func TestRuleActionUnmarshalsFromJSON(t *testing.T) {
+	m := &Middleware{
+		logger:                zap.NewNop(),
+		ruleCache:             NewRuleCache(),
+		requestValueExtractor: NewRequestValueExtractor(zap.NewNop(), false, 0),
+	}
+	m.Rules = map[int][]Rule{}
+	if err := m.loadRules([]string{"rules.json"}); err != nil {
+		t.Fatalf("loadRules: %v", err)
+	}
+	var haveBlock, haveLog bool
+	for _, phaseRules := range m.Rules {
+		for _, r := range phaseRules {
+			switch r.Action {
+			case "block":
+				haveBlock = true
+			case "log":
+				haveLog = true
+			case "":
+				t.Errorf("rule %q loaded with empty Action (json tag regression?)", r.ID)
+			}
+		}
+	}
+	assert.True(t, haveBlock, "rules.json must contain at least one block-action rule")
+	assert.True(t, haveLog, "rules.json must contain at least one log-action rule")
+}
+
+// TestRuleModeKeyStillAccepted pins the compatibility alias: rule files written
+// against the earlier documentation used "mode", and they must keep working.
+// "action" wins when both keys are present.
+func TestRuleModeKeyStillAccepted(t *testing.T) {
+	var rules []Rule
+	src := `[
+	  {"id":"legacy","phase":1,"pattern":"x","targets":["ARGS"],"score":1,"mode":"block"},
+	  {"id":"canonical","phase":1,"pattern":"x","targets":["ARGS"],"score":1,"action":"log"},
+	  {"id":"both","phase":1,"pattern":"x","targets":["ARGS"],"score":1,"action":"log","mode":"block"},
+	  {"id":"neither","phase":1,"pattern":"x","targets":["ARGS"],"score":1}
+	]`
+	if err := json.Unmarshal([]byte(src), &rules); err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, r := range rules {
+		got[r.ID] = r.Action
+	}
+	assert.Equal(t, "block", got["legacy"], `"mode" must still populate Action`)
+	assert.Equal(t, "log", got["canonical"])
+	assert.Equal(t, "log", got["both"], `"action" must win over "mode"`)
+	assert.Equal(t, "", got["neither"])
+}
+
+// TestBlockActionFromJSONBlocksBelowThreshold pins the runtime effect of the
+// tag fix end to end: a rule whose file says "action": "block" blocks on its
+// first match even when its score is below anomaly_threshold. Before the fix
+// this request passed, because Action was "" and blocking happened only once
+// accumulated scores crossed the threshold.
+func TestBlockActionFromJSONBlocksBelowThreshold(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rules.json")
+	rules := `[{"id":"explicit-block","phase":1,"pattern":"^probe$","targets":["HEADERS:X-Probe"],"severity":"LOW","action":"block","score":1,"description":""}]`
+	if err := os.WriteFile(path, []byte(rules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	logger := zap.NewNop()
+	m := &Middleware{
+		logger: logger, blacklistLoader: NewBlacklistLoader(logger),
+		AnomalyThreshold: 20, ruleCache: NewRuleCache(), ipBlacklist: iptrie.NewTrie(),
+		dnsBlacklist: map[string]struct{}{}, ruleHitsByPhase: map[int]int64{},
+		RuleFiles:             []string{path},
+		requestValueExtractor: NewRequestValueExtractor(logger, false, 0),
+		provisionTime:         time.Now(), topIPsBlocked: map[string]int64{},
+		blockedByReason: map[string]int64{}, geoIPStats: map[string]int64{},
+	}
+	if err := m.loadRules(m.RuleFiles); err != nil {
+		t.Fatalf("loadRules: %v", err)
+	}
+	next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) error {
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "203.0.113.9:1234"
+	r.Header.Set("X-Probe", "probe")
+	rec := httptest.NewRecorder()
+	_ = m.ServeHTTP(rec, r, next)
+	assert.Equal(t, http.StatusForbidden, rec.Code, "a block-action rule must block on match regardless of score")
+}

--- a/types.go
+++ b/types.go
@@ -1,6 +1,7 @@
 package caddywaf
 
 import (
+	"encoding/json"
 	"regexp"
 	"sync"
 	"sync/atomic"
@@ -77,7 +78,7 @@ type Rule struct {
 	Targets     []string `json:"targets"`
 	Severity    string   `json:"severity"` // Used for logging only
 	Score       int      `json:"score"`
-	Action      string   `json:"mode"` // CRITICAL FIX: This should map to the "mode" field in JSON
+	Action      string   `json:"action"` // "block" or "log"; "mode" is accepted as an alias, see UnmarshalJSON
 	Description string   `json:"description"`
 	// Transformations is an optional per-rule ModSecurity/CRS-style pipeline
 	// (e.g. ["urlDecodeUni","removeNulls","replaceComments"]) applied to the
@@ -88,6 +89,25 @@ type Rule struct {
 	Transformations *[]string `json:"transformations,omitempty"`
 	regex           *regexp.Regexp
 	Priority        int // New field for rule priority
+}
+
+// UnmarshalJSON reads the rule action from the "action" key, which every
+// shipped rule file uses, and falls back to "mode" so rule files written
+// against the earlier documentation (which named the key "mode") keep working.
+// When both keys are present "action" wins.
+func (r *Rule) UnmarshalJSON(data []byte) error {
+	type plain Rule // no methods, so json.Unmarshal does not recurse into this one
+	aux := struct {
+		*plain
+		Mode string `json:"mode"`
+	}{plain: (*plain)(r)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if r.Action == "" {
+		r.Action = aux.Mode
+	}
+	return nil
 }
 
 // CustomBlockResponse struct


### PR DESCRIPTION
Part 1 of 5 of the rules audit, split out of #194 at the maintainer's request (see [this comment](https://github.com/fabriziosalmi/caddy-waf/pull/194#issuecomment-5549417897)); landing order is 1 → 5.

## Summary

`Rule.Action` was tagged `json:"mode"`, but every shipped rule file keys the field `"action"`, so `Action` unmarshalled to `""` for every rule loaded from JSON. `action: "block"` never caused an explicit block (blocking only ever happened when accumulated scores crossed `anomaly_threshold`), and the `log`/`block` distinction did not exist at runtime.

This PR changes the tag to `json:"action"` and adds `Rule.UnmarshalJSON` so **`mode` is still accepted as an alias** (`action` wins when both are present). That alias matters: `docs/rules.md` told authors to prefer `"mode"` and `sample_rules.json` uses it, so a plain tag change would have broken any rule file written against the docs. The docs now name `action` as the canonical key and the "Field name caveat" section explains the history.

## Behaviour notes for the upgrade

- A `block` rule now blocks on its first match regardless of score. No rule shipped in `rules.json` or the `rules/` bundles is scored below the Caddyfile default threshold of 5, so nothing new is blocked at that setting (you confirmed the same for `rules.json`). With a higher threshold (the JSON-config `Provision` fallback is 20) block rules that used to need accumulation now fire on their own.
- The load-time check that only accepts `block` or `log` is now effective; a custom rule with any other action value fails to load instead of silently running as a score-only rule. All 214 shipped rules use `block` or `log`.

## Tests

`rule_action_test.go`:
- `TestRuleActionUnmarshalsFromJSON` loads the real `rules.json` and asserts every rule has a non-empty `Action` (this is the regression pin you asked for).
- `TestRuleModeKeyStillAccepted` pins the `mode` alias and the `action`-wins precedence.
- `TestBlockActionFromJSONBlocksBelowThreshold` drives `ServeHTTP` with a `block` rule scored 1 at threshold 20 and expects 403.

All three fail on `main` without the fix; `go test ./... -tags=it` is green with it.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
