### PR TITLE
feat(tools): rewrite get_owasp_rules.py as a SecLang→caddy-waf translator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,3 +64,7 @@ jobs:
     - name: Run tests
       run: |
         go test -v -failfast ./... -tags=it
+
+    - name: Run rule-translator unit tests
+      run: |
+        python3 -m unittest -v test_get_owasp_rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`get_owasp_rules.py` is now a real SecLang → caddy-waf translator** (was a regex scrape of `SecRule` lines that validated patterns with Python's `re`, ignored chains and `t:` chains, and could not read `@pmFromFile` keyword lists). It parses continuations, chained rules and quoted actions; ports `@rx` rules as-is and `@pm`/`@pmFromFile` lists as a case-insensitive alternation (sorted so Go's regexp factors the shared prefixes, which is 10–20× faster to match than an unsorted list); maps CRS variables onto targets (`ARGS` → `ARGS` + `BODY`, `REQUEST_HEADERS:Host` → `HOST`, `XML` → `BODY`, …) and `t:` chains onto the engine's `transformations` field; rewrites a leading `^`/trailing `$` on collection targets to a member boundary (ModSecurity matches each parameter value on its own; caddy-waf matches the raw query string); derives the score from the CRS severity and emits every rule as `log` so the output is advisory until `log_scores_block` is set; splits the output by paranoia level and by request/response phase; and applies a tuning file (`<id> remove`, `<id> remove-target BODY`, the caddy-waf equivalent of `SecRuleUpdateTargetById`). Every pattern is validated by `tools/re2check`, a small Go program that compiles it with the same `regexp` package the WAF uses, so a pattern RE2 rejects is skipped at generation time instead of failing to load. A generated `COVERAGE.md` lists every skipped rule with its reason (chained, non-regex operator, `^$` presence check, unsupported transformation, …) and every ported rule that lost a transformation, exclusion or anchor on the way. Unit tests in `test_get_owasp_rules.py` (run by CI). Documented in `docs/scripts.md`.
+
 ## [v0.4.14] - 2026-09-05
 
 ### Added

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -40,7 +40,7 @@ python3 get_owasp_rules.py --source ~/src/coreruleset/rules --paranoia-level 2 \
 
 | Option | Meaning |
 |---|---|
-| `--ref TAG` / `--source DIR` | CRS git tag to download, or a local `rules/` directory (no network). |
+| `--ref TAG` / `--source DIR` | CRS git tag to download (default `v4.9.0`), or a local `rules/` directory (no network; `--ref` then only labels the report). |
 | `--output-dir DIR` | One request bundle per paranoia level (`crs-pl1.json` … `crs-pl4.json`) plus `crs-plN-response.json` for the phase 3/4 rules. |
 | `--output FILE --paranoia-level N` | One cumulative request bundle up to level N; response rules go to `FILE-response.json`. |
 | `--tuning FILE` | Per-rule adjustments, one per line: `<id> remove` drops a rule, `<id> remove-target BODY` keeps it off one target. `#` comments are copied into the report as the reason. |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -55,7 +55,7 @@ What gets ported, and what does not:
 - Skipped, and listed in the report with the reason: chained rules, every non-regex operator (`@detectSQLi`, `@validateByteRange`, `@eq`, …), control-flow rules without a severity, `^$` presence checks (this engine skips a rule whose target is empty), rules whose only variables have no equivalent (`TX`, `&ARGS`, `MULTIPART_*`), rules that need `base64Decode`/`length`/`sha1`, and anything RE2 rejects.
 - A leading `^` or trailing `$` on a collection target (`ARGS`, `BODY`, `HEADERS`, `COOKIES`) is rewritten to a member boundary, because ModSecurity matches each value on its own while caddy-waf matches the whole query string / header list.
 
-The result is CRS-informed coverage, not CRS parity: see [`rules/crs/README.md`](https://github.com/fabriziosalmi/caddy-waf/blob/main/rules/crs/README.md) for the gaps that matter (libinjection, chained rules, parsed parameters) and the per-request cost. Unit tests: `python3 -m unittest test_get_owasp_rules`.
+The result is CRS-informed coverage, not CRS parity: the generated `COVERAGE.md` lists the gaps that matter (libinjection, chained rules, parsed parameters), and the [OWASP CRS section of `rules/README.md`](https://github.com/fabriziosalmi/caddy-waf/blob/main/rules/README.md#owasp-crs) covers loading the output. Unit tests: `python3 -m unittest test_get_owasp_rules`.
 
 ### `get_spiderlabs_rules.py`
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -8,7 +8,7 @@ All scripts target Python 3 and use only the standard library plus `requests` (a
 
 | Script | Inputs | Output | Purpose |
 |---|---|---|---|
-| [`get_owasp_rules.py`](https://github.com/fabriziosalmi/caddy-waf/blob/main/get_owasp_rules.py) | OWASP Core Rule Set repository (`coreruleset/coreruleset`) on GitHub | `rules.json` (overwritten / appended) | Downloads OWASP CRS `.conf` files via the GitHub API, parses `SecRule` directives, and converts them into the WAF's JSON rule schema. |
+| [`get_owasp_rules.py`](https://github.com/fabriziosalmi/caddy-waf/blob/main/get_owasp_rules.py) | An OWASP Core Rule Set release tarball (`coreruleset/coreruleset`, default `v4.9.0`) or a local `rules/` checkout | `rules/crs/crs-pl{1..4}.json`, `crs-pl{N}-response.json`, `COVERAGE.md` | SecLang → caddy-waf translator. Parses `SecRule` directives (continuations, chains, quoted actions), ports the `@rx`/`@pm`/`@pmFromFile` rules, maps variables to targets and `t:` chains to `transformations`, validates every pattern with Go's RE2, and writes a coverage report of what was skipped and why. |
 | [`get_spiderlabs_rules.py`](https://github.com/fabriziosalmi/caddy-waf/blob/main/get_spiderlabs_rules.py) | Trustwave SpiderLabs ModSecurity rules | `spiderlabs_rules.json` | Same idea as the OWASP script, sourced from SpiderLabs. Keeps only `@rx` (regex) rules and strips the operator, so the output compiles under RE2; non-regex operators are skipped. |
 | [`get_vulnerability_rules.py`](https://github.com/fabriziosalmi/caddy-waf/blob/main/get_vulnerability_rules.py) | A built-in dictionary of CVE-style payloads | `rules.json` | Generates rules from a predefined payload table without any network calls. |
 | [`get_blacklisted_ip.py`](https://github.com/fabriziosalmi/caddy-waf/blob/main/get_blacklisted_ip.py) | Emerging Threats, CI Army, IPsum, BlockList.de, Greensnow, Tor exit-address feed | `ip_blacklist.txt` | Downloads multiple IP feeds, merges them, deduplicates, and writes one IP/CIDR per line. |
@@ -29,16 +29,33 @@ All scripts require outbound HTTPS access to their respective sources.
 
 ### `get_owasp_rules.py`
 
-Edit the constants at the top of the script (repo URL, rules directory, output path) if you want a non-default location. Run:
-
 ```bash
-python3 get_owasp_rules.py
+# Regenerate the shipped bundles (downloads the CRS v4.9.0 tarball from GitHub):
+python3 get_owasp_rules.py --ref v4.9.0 --output-dir rules/crs --tuning rules/crs/tuning.txt
+
+# One cumulative file up to paranoia level 2, from a local CRS checkout:
+python3 get_owasp_rules.py --source ~/src/coreruleset/rules --paranoia-level 2 \
+    --output /etc/caddy/crs-pl2.json --report /etc/caddy/crs-coverage.md
 ```
 
-Notes:
+| Option | Meaning |
+|---|---|
+| `--ref TAG` / `--source DIR` | CRS git tag to download, or a local `rules/` directory (no network). |
+| `--output-dir DIR` | One request bundle per paranoia level (`crs-pl1.json` … `crs-pl4.json`) plus `crs-plN-response.json` for the phase 3/4 rules. |
+| `--output FILE --paranoia-level N` | One cumulative request bundle up to level N; response rules go to `FILE-response.json`. |
+| `--tuning FILE` | Per-rule adjustments: `<id> remove` drops a rule, `<id> remove-target BODY` keeps it off one target. `#` comments are copied into the report as the reason. |
+| `--exclude 920350,920440` | Ad hoc rule removal without a tuning file. |
+| `--block-severity CRITICAL` | Emit `"action": "block"` for rules at or above that severity. Default: every rule is `log` (advisory). |
+| `--re2check go\|python\|auto` | Pattern validator. `go` runs `go run ./tools/re2check` so patterns are compiled by the same `regexp` package caddy-waf uses; `python` is a syntax heuristic for machines without Go. |
+| `--report FILE` | Where to write the coverage report (default `COVERAGE.md` next to the output). |
 
-- The script uses the unauthenticated GitHub API. For large repositories you may hit rate limits (60 requests/hour per IP); add a `GITHUB_TOKEN` to the `headers` dictionary if needed.
-- The conversion from ModSecurity `SecRule` to the WAF JSON schema is heuristic. Validate the output before deploying — some rules may need manual touch-ups.
+What gets ported, and what does not:
+
+- Ported: `@rx` rules as-is; `@pm`/`@pmFromFile` keyword lists as a case-insensitive alternation (sorted so Go can factor common prefixes; unsorted lists are 10–20× slower to match); `t:` chains mapped onto the engine's `transformations` (unsupported steps such as `cmdLine` and `jsDecode` are dropped with a note, `removeWhitespace` is approximated by `compressWhitespace`); CRS variables mapped onto targets (`ARGS` → `ARGS` + `BODY`, `REQUEST_HEADERS:Host` → `HOST`, `XML` → `BODY`, …); severity → score (CRITICAL 5, ERROR 4, WARNING 3, NOTICE 2); the `paranoia-level/N` tag → output file.
+- Skipped, and listed in the report with the reason: chained rules, every non-regex operator (`@detectSQLi`, `@validateByteRange`, `@eq`, …), control-flow rules without a severity, `^$` presence checks (this engine skips a rule whose target is empty), rules whose only variables have no equivalent (`TX`, `&ARGS`, `MULTIPART_*`), rules that need `base64Decode`/`length`/`sha1`, and anything RE2 rejects.
+- A leading `^` or trailing `$` on a collection target (`ARGS`, `BODY`, `HEADERS`, `COOKIES`) is rewritten to a member boundary, because ModSecurity matches each value on its own while caddy-waf matches the whole query string / header list.
+
+The result is CRS-informed coverage, not CRS parity: see [`rules/crs/README.md`](https://github.com/fabriziosalmi/caddy-waf/blob/main/rules/crs/README.md) for the gaps that matter (libinjection, chained rules, parsed parameters) and the per-request cost. Unit tests: `python3 -m unittest test_get_owasp_rules`.
 
 ### `get_spiderlabs_rules.py`
 
@@ -91,8 +108,8 @@ To keep blacklists fresh, schedule the scripts with `cron` or systemd timers. Re
 0 */6 * * * cd /etc/caddy && /usr/bin/python3 get_blacklisted_ip.py  >> /var/log/caddy/ip-feed.log  2>&1
 0 */6 * * * cd /etc/caddy && /usr/bin/python3 get_blacklisted_dns.py >> /var/log/caddy/dns-feed.log 2>&1
 
-# Refresh rules nightly
-30 3 * * *  cd /etc/caddy && /usr/bin/python3 get_owasp_rules.py     >> /var/log/caddy/owasp.log    2>&1
+# Refresh the CRS bundle nightly (re-validates against RE2; needs the go toolchain)
+30 3 * * *  cd /etc/caddy && /usr/bin/python3 get_owasp_rules.py --output /etc/caddy/feeds/crs-pl1.json --tuning /etc/caddy/crs-tuning.txt >> /var/log/caddy/owasp.log 2>&1
 ```
 
 When the script writes a new `ip_blacklist.txt` or `dns_blacklist.txt` over the file pointed to by the corresponding `*_file` directive, the file watcher fires and the WAF rebuilds the prefix trie / DNS map atomically (see [dynamicupdates.md](dynamicupdates.md)).

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -30,8 +30,8 @@ All scripts require outbound HTTPS access to their respective sources.
 ### `get_owasp_rules.py`
 
 ```bash
-# Regenerate the shipped bundles (downloads the CRS v4.9.0 tarball from GitHub):
-python3 get_owasp_rules.py --ref v4.9.0 --output-dir rules/crs --tuning rules/crs/tuning.txt
+# One request bundle per paranoia level, downloading the CRS v4.9.0 tarball from GitHub:
+python3 get_owasp_rules.py --ref v4.9.0 --output-dir rules/crs
 
 # One cumulative file up to paranoia level 2, from a local CRS checkout:
 python3 get_owasp_rules.py --source ~/src/coreruleset/rules --paranoia-level 2 \
@@ -43,10 +43,10 @@ python3 get_owasp_rules.py --source ~/src/coreruleset/rules --paranoia-level 2 \
 | `--ref TAG` / `--source DIR` | CRS git tag to download, or a local `rules/` directory (no network). |
 | `--output-dir DIR` | One request bundle per paranoia level (`crs-pl1.json` … `crs-pl4.json`) plus `crs-plN-response.json` for the phase 3/4 rules. |
 | `--output FILE --paranoia-level N` | One cumulative request bundle up to level N; response rules go to `FILE-response.json`. |
-| `--tuning FILE` | Per-rule adjustments: `<id> remove` drops a rule, `<id> remove-target BODY` keeps it off one target. `#` comments are copied into the report as the reason. |
+| `--tuning FILE` | Per-rule adjustments, one per line: `<id> remove` drops a rule, `<id> remove-target BODY` keeps it off one target. `#` comments are copied into the report as the reason. |
 | `--exclude 920350,920440` | Ad hoc rule removal without a tuning file. |
 | `--block-severity CRITICAL` | Emit `"action": "block"` for rules at or above that severity. Default: every rule is `log` (advisory). |
-| `--re2check go\|python\|auto` | Pattern validator. `go` runs `go run ./tools/re2check` so patterns are compiled by the same `regexp` package caddy-waf uses; `python` is a syntax heuristic for machines without Go. |
+| `--re2check go\|python\|auto` | Pattern validator. `go` runs `go run ./tools/re2check` so patterns are compiled by the same `regexp` package caddy-waf uses and fails if that is not possible; `python` is a syntax heuristic (lookaround, backreferences) for machines without Go; `auto` (default) uses Go when the helper and toolchain are available and warns and falls back otherwise, e.g. when the script has been copied out of the repository. |
 | `--report FILE` | Where to write the coverage report (default `COVERAGE.md` next to the output). |
 
 What gets ported, and what does not:
@@ -109,7 +109,7 @@ To keep blacklists fresh, schedule the scripts with `cron` or systemd timers. Re
 0 */6 * * * cd /etc/caddy && /usr/bin/python3 get_blacklisted_dns.py >> /var/log/caddy/dns-feed.log 2>&1
 
 # Refresh the CRS bundle nightly (re-validates against RE2; needs the go toolchain)
-30 3 * * *  cd /etc/caddy && /usr/bin/python3 get_owasp_rules.py --output /etc/caddy/feeds/crs-pl1.json --tuning /etc/caddy/crs-tuning.txt >> /var/log/caddy/owasp.log 2>&1
+30 3 * * *  cd /etc/caddy && /usr/bin/python3 get_owasp_rules.py --output /etc/caddy/feeds/crs-pl1.json >> /var/log/caddy/owasp.log 2>&1
 ```
 
 When the script writes a new `ip_blacklist.txt` or `dns_blacklist.txt` over the file pointed to by the corresponding `*_file` directive, the file watcher fires and the WAF rebuilds the prefix trie / DNS map atomically (see [dynamicupdates.md](dynamicupdates.md)).

--- a/get_owasp_rules.py
+++ b/get_owasp_rules.py
@@ -765,9 +765,10 @@ def translate_directory(
             result, skip = translate_rule(rule, rules_dir)
             if result and rule.id in tuning.remove_targets:
                 for target, reason in tuning.remove_targets[rule.id].items():
-                    if target in result.rule["targets"]:
-                        result.rule["targets"].remove(target)
-                        result.notes.append(f"target {target} removed by tuning: {reason}")
+                    present = [t for t in result.rule["targets"] if t.lower() == target.lower()]
+                    for t in present:
+                        result.rule["targets"].remove(t)
+                        result.notes.append(f"target {t} removed by tuning: {reason}")
                 if not result.rule["targets"]:
                     skip, result = Skipped(rule.id, name, "removed by tuning", "every target removed"), None
             if skip:
@@ -961,7 +962,7 @@ def download_crs(ref: str, dest: str) -> str:
     """Download the CRS tarball for ``ref`` and return the extracted rules dir."""
     url = f"https://github.com/{CRS_REPO}/archive/refs/tags/{ref}.tar.gz"
     print(f"Downloading {url}")
-    with urllib.request.urlopen(url) as resp:  # noqa: S310 - fixed GitHub URL
+    with urllib.request.urlopen(url, timeout=60) as resp:  # noqa: S310 - fixed GitHub URL
         data = resp.read()
     with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
         members = [m for m in tar.getmembers() if "/rules/" in m.name and m.isfile()]
@@ -974,6 +975,12 @@ def download_crs(ref: str, dest: str) -> str:
                 continue
             tar.extract(m, dest)
     return os.path.join(dest, "rules")
+
+
+def normalize_target(target: str) -> str:
+    """Upper-case the base name, keep a selector as written (``HEADERS:User-Agent``)."""
+    base, sep, selector = target.strip().partition(":")
+    return base.upper() + sep + selector
 
 
 @dataclass
@@ -1013,7 +1020,7 @@ def read_tuning(path: Optional[str], inline_exclude: Optional[str]) -> Tuning:
                 tuning.remove[rule_id] = reason
             elif directive == "remove-target" and len(words) == 3:
                 for target in words[2].split(","):
-                    tuning.remove_targets.setdefault(rule_id, {})[target.strip().upper()] = reason
+                    tuning.remove_targets.setdefault(rule_id, {})[normalize_target(target)] = reason
             else:
                 raise SystemExit(f"{path}:{number}: expected '<id> remove' or '<id> remove-target <TARGET[,TARGET]>'")
     return tuning

--- a/get_owasp_rules.py
+++ b/get_owasp_rules.py
@@ -1021,9 +1021,8 @@ def read_tuning(path: Optional[str], inline_exclude: Optional[str]) -> Tuning:
 
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    src = parser.add_mutually_exclusive_group()
-    src.add_argument("--source", help="local CRS rules/ directory (skips the download)")
-    src.add_argument("--ref", default=DEFAULT_REF, help=f"CRS git tag to download (default {DEFAULT_REF})")
+    parser.add_argument("--source", help="local CRS rules/ directory (skips the download; --ref then only labels the report)")
+    parser.add_argument("--ref", default=DEFAULT_REF, help=f"CRS git tag to download (default {DEFAULT_REF})")
     out = parser.add_mutually_exclusive_group()
     out.add_argument("--output-dir", help="write one request bundle per paranoia level (crs-pl1.json … crs-pl4.json) "
                      "plus the response-phase rules as crs-plN-response.json")
@@ -1043,7 +1042,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     if not args.output_dir and not args.output:
         args.output_dir = "rules/crs"
     repo_root = os.path.dirname(os.path.abspath(__file__))
-    ref = args.ref if not args.source else os.path.basename(os.path.dirname(os.path.abspath(args.source))) or "local"
+    ref = args.ref
 
     with tempfile.TemporaryDirectory() as tmp:
         rules_dir = args.source or download_crs(args.ref, tmp)

--- a/get_owasp_rules.py
+++ b/get_owasp_rules.py
@@ -1,151 +1,1071 @@
-import requests  # For making HTTP requests to GitHub API and downloading files
-import re        # For regular expression pattern matching
-import json      # For JSON serialization
-import time      # For adding delays between API requests
+#!/usr/bin/env python3
+"""Translate OWASP ModSecurity Core Rule Set (CRS) SecLang rules into caddy-waf JSON.
 
-def download_owasp_rules(repo_url, rules_dir, output_path):
-    """
-    Downloads and processes OWASP ModSecurity Core Rule Set (CRS) files from GitHub.
-    
-    Args:
-        repo_url (str): GitHub repository path (e.g., 'coreruleset/coreruleset')
-        rules_dir (str): Directory containing rule files in the repository
-        output_path (str): Path where processed rules will be saved as JSON
-    """
-    all_rules = []
-    headers = {}  # Can be used to add GitHub API token if needed
-    
-    try:
-        # Construct GitHub API URL to list contents of rules directory
-        api_url = f"https://api.github.com/repos/{repo_url}/contents/{rules_dir}"
-        response = requests.get(api_url, headers=headers)
-        response.raise_for_status()
-        
-        # Process each .conf file in the directory
-        for file in response.json():
-            if not file['name'].endswith('.conf'):
-                continue
-                
-            # Add delay to avoid hitting GitHub API rate limits
-            time.sleep(1)
-            response = requests.get(file["download_url"], headers=headers)
-            print(f"Processing rule file: {file['name']}")
-            
-            # Extract rules from file content and add to collection
-            rules = extract_rules(response.text)
-            all_rules.extend(rules)
-            
-    except requests.exceptions.RequestException as e:
-        print(f"Error: {e}")
-        return
-        
-    # Save processed rules to JSON file
-    with open(output_path, 'w') as f:
-        json.dump(all_rules, f, indent=2)
-    print(f"Saved {len(all_rules)} rules to {output_path}")
+caddy-waf matches one Go RE2 regular expression against one or more request
+targets, adds the rule's score and decides on block/log. ModSecurity's SecLang
+is a much larger language (operators, chained rules, transaction variables,
+structured body parsers, paranoia-level control flow). This script ports the
+subset that maps onto the caddy-waf model and writes a coverage report that
+says exactly what it could not port, so the gap is documented rather than
+hidden. The result is CRS-informed coverage, not CRS parity.
 
-def extract_rules(rule_text):
-    """
-    Extracts individual ModSecurity rules from rule file content using regex.
-    
-    Args:
-        rule_text (str): Content of ModSecurity rule file
-        
-    Returns:
-        list: List of dictionaries containing parsed rule information
-    """
-    rules = []
-    # ModSecurity wraps long rules across lines with a trailing backslash; join those
-    # continuations first, otherwise a multi-line SecRule is parsed in pieces.
-    rule_text = re.sub(r"\\\s*\n\s*", " ", rule_text)
-    # Match `SecRule VARIABLES "OPERATOR" ACTIONS`. The operator is a quoted string that
-    # may itself contain escaped quotes (e.g. @rx "...\"..."), so the old `"([^"]+)"`
-    # truncated any CRS rule with a `\"` in it into an invalid pattern (issue #149).
-    # `(?:\\.|[^"\\])*` consumes escaped chars correctly; rules are bounded at line-start.
-    rule_pattern = re.compile(
-        r'^\s*SecRule\s+(?P<variables>\S+)\s+"(?P<expression>(?:\\.|[^"\\])*)"\s+(?P<actions>.*?)(?=^\s*SecRule|\Z)',
-        re.MULTILINE | re.DOTALL,
-    )
+What is ported
+    * ``@rx`` rules: the regex is used as-is after RE2 validation.
+    * ``@pm`` / ``@pmFromFile`` rules: the keyword list becomes a
+      case-insensitive alternation.
+    * ``t:`` transformation chains, mapped onto caddy-waf's ``transformations``
+      field (see ``TRANSFORMATIONS``).
+    * SecLang variables, mapped onto caddy-waf targets (see ``VARIABLES``).
+    * Severity → score (CRITICAL 5, ERROR 4, WARNING 3, NOTICE 2) and the
+      paranoia level from the ``paranoia-level/N`` tag.
 
-    for match in rule_pattern.finditer(rule_text):
-        try:
-            variables = match.group("variables")
-            actions = match.group("actions")
-            # The quoted operator is `@<op> <argument>`. caddy-waf is a regex engine,
-            # so keep @rx rules (using the argument as the pattern) and skip non-regex
-            # operators (@pm, @streq, @detectSQLi, …) that cannot be expressed as a regex.
-            expr = match.group("expression").strip()
-            op = re.match(r'@(\w+)\s+(.*)', expr, re.DOTALL)
-            if op:
-                if op.group(1) != 'rx':
-                    continue
-                pattern = op.group(2)
-            else:
-                pattern = expr  # a bare pattern is an implicit @rx
-            
-            # Extract key rule properties using regex
-            rule_id = re.search(r'id:(\d+)', actions)
-            severity = re.search(r'severity:\'?([^,\'\s]+)', actions)
-            action = re.search(r'action:\'?([^,\'\s]+)', actions)
-            phase = re.search(r'phase:(\d+)', actions)
-            description = re.search(r'msg:\'?([^\']+)\'', actions)
-            
-            if not rule_id:
-                continue
-                
-            # Handle special characters in pattern
-            pattern = pattern.replace('[CDATA[', '\\[CDATA\\[')
-            
-            # Validate regex pattern
-            try:
-                re.compile(pattern)
-            except re.error:
-                print(f"Invalid regex pattern in rule {rule_id.group(1)}: {pattern}")
-                continue
-                
-            # Extract targeted variables from rule
-            targets = []
-            if variables:
-                # List of possible ModSecurity variables to check for
-                for target in ["ARGS", "BODY", "URL", "HEADERS", "REQUEST_HEADERS", 
-                             "RESPONSE_HEADERS", "REQUEST_COOKIES", "USER_AGENT", 
-                             "CONTENT_TYPE", "X-FORWARDED-FOR", "X-REAL-IP"]:
-                    if target in variables.upper():
-                        targets.append(target)
-            
-            # Set default values if properties are missing
-            severity_val = severity.group(1) if severity else "LOW"
-            action_val = action.group(1) if action else "log"
-            description_val = description.group(1) if description else "No description provided."
-            
-            # Calculate rule score based on severity and action
-            score = 0 if action_val == "pass" else \
-                    5 if action_val == "block" else \
-                    4 if severity_val.upper() == "HIGH" else \
-                    3 if severity_val.upper() == "MEDIUM" else 1
-            
-            # Create rule dictionary with extracted information
-            rule = {
-                "id": rule_id.group(1),
-                "phase": int(phase.group(1)) if phase else 2,
-                "pattern": pattern,
-                "targets": targets,
-                "severity": severity_val,
-                "action": action_val,
-                "score": score,
-                "description": description_val
-            }
-            rules.append(rule)
-            
-        except (AttributeError, ValueError) as e:
+What is skipped (each one is listed in the coverage report with its reason)
+    * chained rules, negated operators, every non-regex operator
+      (``@detectSQLi``, ``@eq``, ``@validateByteRange``, …),
+    * rules whose only variables have no caddy-waf equivalent (``TX``,
+      ``MATCHED_VAR``, ``&ARGS`` counts, ``FILES_TMP_CONTENT``, …),
+    * rules that need a transformation which changes the value's meaning
+      (``length``, ``base64Decode``, ``sha1``, …),
+    * patterns that Go's RE2 rejects, and patterns containing ``%{...}``
+      macros.
+
+Every emitted rule uses ``"action": "log"`` by default: since v0.4.14 a log
+rule's score is advisory and never blocks on its own. Add ``log_scores_block``
+(and ``anomaly_threshold 5``) to a Caddyfile to get CRS-style anomaly-score
+blocking, or pass ``--block-severity CRITICAL`` to emit block rules.
+
+Usage
+    python3 get_owasp_rules.py --ref v4.9.0 --output-dir rules/crs
+    python3 get_owasp_rules.py --source /path/to/coreruleset/rules \\
+        --paranoia-level 2 --output crs-pl2.json --report crs-pl2-coverage.md
+
+Request-phase rules (phases 1-2) and response-phase rules (phases 3-4, the
+CRS 95x data-leakage and web-shell checks) are written to separate files,
+``<name>.json`` and ``<name>-response.json``, because response rules run
+against every response body and are the more expensive half.
+
+Validation uses Go: the script runs ``go run ./tools/re2check`` from the
+repository root so every pattern is compiled by the same regexp package
+caddy-waf uses. Pass ``--re2check python`` on a machine without Go to fall
+back to a syntax heuristic that rejects lookaround and backreferences only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+from collections import Counter, OrderedDict
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Tuple
+
+CRS_REPO = "coreruleset/coreruleset"
+DEFAULT_REF = "v4.9.0"
+
+SEVERITY_SCORE = {"CRITICAL": 5, "ERROR": 4, "WARNING": 3, "NOTICE": 2}
+SEVERITY_ORDER = ["NOTICE", "WARNING", "ERROR", "CRITICAL"]
+
+# Operators this engine can express as a regex. Everything else is skipped.
+REGEX_OPERATORS = {"rx", "pm", "pmFromFile", "pmf"}
+
+# CRS variable -> caddy-waf target(s). ``None`` marks a variable the engine has
+# no equivalent for; a rule whose positive variables all map to None is skipped.
+# ARGS in ModSecurity covers query and body parameters, while caddy-waf's ARGS
+# is the raw query string, so ARGS fans out to ARGS + BODY (raw body). XML is
+# not parsed either: the raw body is the closest available value.
+VARIABLES: Dict[str, Optional[Tuple[str, ...]]] = {
+    "ARGS": ("ARGS", "BODY"),
+    "ARGS_NAMES": ("ARGS", "BODY"),
+    "ARGS_GET": ("ARGS",),
+    "ARGS_GET_NAMES": ("ARGS",),
+    "ARGS_POST": ("BODY",),
+    "ARGS_POST_NAMES": ("BODY",),
+    "ARGS_COMBINED_SIZE": None,
+    "REQUEST_BODY": ("BODY",),
+    "XML": ("BODY",),
+    "REQUEST_COOKIES": ("COOKIES",),
+    "REQUEST_COOKIES_NAMES": ("COOKIES",),
+    "REQUEST_HEADERS": ("HEADERS",),
+    "REQUEST_HEADERS_NAMES": ("HEADERS",),
+    "REQUEST_FILENAME": ("PATH",),
+    "REQUEST_BASENAME": ("PATH",),
+    "REQUEST_URI": ("URI",),
+    "REQUEST_URI_RAW": ("URI",),
+    "REQUEST_LINE": ("URI",),
+    "QUERY_STRING": ("ARGS",),
+    "REQUEST_METHOD": ("METHOD",),
+    "REQUEST_PROTOCOL": ("PROTOCOL",),
+    "FILES": ("FILE_NAME",),
+    "FILES_NAMES": ("FILE_NAME",),
+    "FILES_TMPNAMES": None,
+    "FILES_TMP_CONTENT": None,
+    "FILES_COMBINED_SIZE": None,
+    "FILES_SIZES": None,
+    "RESPONSE_BODY": ("RESPONSE_BODY",),
+    "RESPONSE_HEADERS": ("RESPONSE_HEADERS",),
+    "RESPONSE_STATUS": None,
+    "RESPONSE_CONTENT_TYPE": ("RESPONSE_HEADERS:Content-Type",),
+    "REMOTE_ADDR": ("REMOTE_IP",),
+    "TX": None,
+    "MATCHED_VAR": None,
+    "MATCHED_VARS": None,
+    "MATCHED_VAR_NAME": None,
+    "MATCHED_VARS_NAMES": None,
+    "REQBODY_PROCESSOR": None,
+    "REQBODY_ERROR": None,
+    "REQBODY_PROCESSOR_ERROR": None,
+    "MULTIPART_STRICT_ERROR": None,
+    "MULTIPART_UNMATCHED_BOUNDARY": None,
+    "MULTIPART_PART_HEADERS": None,
+    "MULTIPART_FILENAME": None,
+    "MULTIPART_NAME": None,
+    "REQUEST_HEADERS_COUNT": None,
+    "ENV": None,
+    "GEO": None,
+    "IP": None,
+    "GLOBAL": None,
+    "SESSION": None,
+    "RESOURCE": None,
+    "USER": None,
+    "DURATION": None,
+    "UNIQUE_ID": None,
+    "SERVER_NAME": None,
+    "SERVER_ADDR": None,
+    "SERVER_PORT": None,
+    "REMOTE_HOST": None,
+    "REMOTE_PORT": None,
+    "REMOTE_USER": None,
+    "AUTH_TYPE": None,
+    "FULL_REQUEST": None,
+    "FULL_REQUEST_LENGTH": None,
+    "PATH_INFO": None,
+    "REQUEST_BODY_LENGTH": None,
+    "INBOUND_DATA_ERROR": None,
+    "OUTBOUND_DATA_ERROR": None,
+    "STREAM_INPUT_BODY": None,
+    "STREAM_OUTPUT_BODY": None,
+    "WEBSERVER_ERROR_LOG": None,
+    "XML_ERROR": None,
+}
+
+# Variables whose selector (``NAME:selector``) becomes a dynamic caddy-waf
+# target. A regex selector (``/.../``) cannot be expressed and falls back to the
+# whole collection.
+SELECTOR_TARGETS = {
+    "REQUEST_HEADERS": "HEADERS",
+    "REQUEST_COOKIES": "COOKIES",
+    "RESPONSE_HEADERS": "RESPONSE_HEADERS",
+    "ARGS": "URL_PARAM",
+    "ARGS_GET": "URL_PARAM",
+}
+
+# Transformations the engine implements (canonical spelling), listed in
+# transform.go. ``urlDecode`` and ``urlDecodeUni`` are both accepted there.
+ENGINE_TRANSFORMS = {
+    "urldecode": "urlDecode",
+    "urldecodeuni": "urlDecodeUni",
+    "lowercase": "lowercase",
+    "removenulls": "removeNulls",
+    "compresswhitespace": "compressWhitespace",
+    "replacecomments": "replaceComments",
+    "htmlentitydecode": "htmlEntityDecode",
+}
+
+# CRS transformations with no engine implementation. ``approx`` maps to the
+# nearest engine transformation; ``drop`` removes the step, which only loses
+# evasion coverage (the raw value is always matched too); ``skip`` means the
+# transformation changes the value's meaning, so the rule cannot be ported.
+TRANSFORMATIONS = {
+    "removewhitespace": ("approx", "compressWhitespace"),
+    "removecomments": ("approx", "replaceComments"),
+    "removecommentschar": ("approx", "replaceComments"),
+    "utf8tounicode": ("drop", None),
+    "normalisepath": ("drop", None),
+    "normalizepath": ("drop", None),
+    "normalisepathwin": ("drop", None),
+    "normalizepathwin": ("drop", None),
+    "cmdline": ("drop", None),
+    "jsdecode": ("drop", None),
+    "cssdecode": ("drop", None),
+    "escapeseqdecode": ("drop", None),
+    "trim": ("drop", None),
+    "trimleft": ("drop", None),
+    "trimright": ("drop", None),
+    "length": ("skip", None),
+    "base64decode": ("skip", None),
+    "base64decodeext": ("skip", None),
+    "base64encode": ("skip", None),
+    "hexdecode": ("skip", None),
+    "hexencode": ("skip", None),
+    "sha1": ("skip", None),
+    "md5": ("skip", None),
+    "urlencode": ("skip", None),
+    "sqlhexdecode": ("skip", None),
+    "parityeven7bit": ("skip", None),
+    "parityodd7bit": ("skip", None),
+    "parityzero7bit": ("skip", None),
+    "uppercase": ("skip", None),
+}
+
+# caddy-waf targets whose raw value is not URL-decoded by Go, so the CRS
+# pattern (written against ModSecurity's decoded ARGS) needs a decode first.
+RAW_TARGETS = {"ARGS", "BODY", "URI"}
+
+# Targets that hold a whole collection in one string: the raw query string
+# (``a=1&b=2``), the raw body, all headers joined as ``Name: value; Name: value``
+# and all cookies joined as ``name=value; name=value``. ModSecurity applies a
+# CRS pattern to each member value on its own, so ``^``/``$`` mean "start/end of
+# the value"; against the joined string they would mean "start/end of the
+# whole request part" and the rule could only match the first/last member.
+# The translator therefore relaxes a leading ``^`` to "start or just after a
+# member delimiter" and a trailing ``$`` to "end or just before one".
+COLLECTION_TARGETS = {"ARGS", "BODY", "HEADERS", "COOKIES"}
+RELAXED_START = r'(?:^|[&="]|:\s*)'
+RELAXED_END = r'(?:$|[&;"])'
+LEADING_FLAGS = re.compile(r"^\(\?[a-zA-Z]+\)")
+
+# PCRE-only syntax RE2 rejects. Used by the Python fallback validator only.
+PCRE_ONLY = re.compile(r"\(\?[=!<]|\(\?<[=!]|\(\?>|(?<!\\)\\[1-9]|\\[kK]<|(?<!\\)\\[GRhHKXZ]|(?<!\\)[+*?}]\+")
+
+
+class SecLangError(ValueError):
+    """Raised for a directive the parser cannot make sense of."""
+
+
+@dataclass
+class Variable:
+    name: str
+    selector: Optional[str] = None
+    negated: bool = False
+    counted: bool = False
+
+
+@dataclass
+class SecRule:
+    file: str
+    line: int
+    variables: List[Variable]
+    operator: str  # e.g. "rx"; "" for an implicit @rx
+    argument: str
+    negated: bool
+    actions: List[Tuple[str, str]]  # (key, value); value "" for bare actions
+    children: List["SecRule"] = field(default_factory=list)
+
+    def action_values(self, key: str) -> List[str]:
+        return [v for k, v in self.actions if k == key]
+
+    def first_action(self, key: str) -> Optional[str]:
+        for k, v in self.actions:
+            if k == key:
+                return v
+        return None
+
+    def has_action(self, key: str) -> bool:
+        return any(k == key for k, _ in self.actions)
+
+    @property
+    def id(self) -> Optional[str]:
+        return self.first_action("id")
+
+    @property
+    def paranoia_level(self) -> int:
+        for tag in self.action_values("tag"):
+            m = re.fullmatch(r"paranoia-level/(\d)", tag)
+            if m:
+                return int(m.group(1))
+        return 1
+
+
+@dataclass
+class Translated:
+    rule: OrderedDict
+    paranoia_level: int
+    notes: List[str]
+    source_file: str
+
+
+@dataclass
+class Skipped:
+    id: str
+    source_file: str
+    category: str
+    detail: str = ""
+
+    @property
+    def reason(self) -> str:
+        return f"{self.category}: {self.detail}" if self.detail else self.category
+
+
+# --------------------------------------------------------------------------- #
+# SecLang parsing
+# --------------------------------------------------------------------------- #
+
+def join_continuations(text: str) -> List[Tuple[int, str]]:
+    """Return (first_line_number, logical_line) pairs with ``\\``-continuations joined."""
+    out: List[Tuple[int, str]] = []
+    buf: List[str] = []
+    start = 0
+    for number, raw in enumerate(text.splitlines(), 1):
+        line = raw.rstrip()
+        if not buf:
+            start = number
+        if line.endswith("\\"):
+            buf.append(line[:-1].rstrip() if buf else line[:-1])
             continue
-            
+        buf.append(line.lstrip() if buf else line)
+        out.append((start, " ".join(buf) if len(buf) > 1 else buf[0]))
+        buf = []
+    if buf:
+        out.append((start, " ".join(buf)))
+    return out
+
+
+def tokenize_directive(line: str) -> List[str]:
+    """Split a directive into whitespace-separated tokens honouring ``"…"`` quoting.
+
+    Inside a quoted token ``\\"`` is an escaped quote; every other backslash is
+    kept verbatim because it belongs to the regex.
+    """
+    tokens: List[str] = []
+    i, n = 0, len(line)
+    while i < n:
+        while i < n and line[i].isspace():
+            i += 1
+        if i >= n:
+            break
+        if line[i] == '"':
+            j = i + 1
+            buf: List[str] = []
+            while j < n and line[j] != '"':
+                if line[j] == "\\" and j + 1 < n:
+                    if line[j + 1] == '"':
+                        buf.append('"')
+                        j += 2
+                        continue
+                    buf.append(line[j])
+                    buf.append(line[j + 1])
+                    j += 2
+                    continue
+                buf.append(line[j])
+                j += 1
+            if j >= n:
+                raise SecLangError("unterminated quoted string")
+            tokens.append("".join(buf))
+            i = j + 1
+        else:
+            j = i
+            while j < n and not line[j].isspace():
+                j += 1
+            tokens.append(line[i:j])
+            i = j
+    return tokens
+
+
+def split_actions(text: str) -> List[Tuple[str, str]]:
+    """Split ``id:1,msg:'a, b',t:none`` into (key, value) pairs."""
+    parts: List[str] = []
+    buf: List[str] = []
+    in_quote = False
+    i = 0
+    while i < len(text):
+        c = text[i]
+        if c == "\\" and i + 1 < len(text) and in_quote:
+            buf.append(text[i + 1])
+            i += 2
+            continue
+        if c == "'":
+            in_quote = not in_quote
+        elif c == "," and not in_quote:
+            parts.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(c)
+        i += 1
+    parts.append("".join(buf))
+
+    actions: List[Tuple[str, str]] = []
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+        key, sep, value = part.partition(":")
+        value = value.strip()
+        if len(value) >= 2 and value[0] == "'" and value[-1] == "'":
+            value = value[1:-1]
+        actions.append((key.strip(), value if sep else ""))
+    return actions
+
+
+def parse_variables(text: str) -> List[Variable]:
+    variables: List[Variable] = []
+    for item in text.split("|"):
+        item = item.strip()
+        if not item:
+            continue
+        negated = counted = False
+        if item[0] == "!":
+            negated = True
+            item = item[1:]
+        elif item[0] == "&":
+            counted = True
+            item = item[1:]
+        name, _, selector = item.partition(":")
+        selector = selector.strip() or None
+        if selector and len(selector) >= 2 and selector[0] == "'" and selector[-1] == "'":
+            selector = selector[1:-1]
+        variables.append(Variable(name.strip().upper(), selector, negated, counted))
+    return variables
+
+
+def parse_operator(text: str) -> Tuple[str, str, bool]:
+    """Return (operator, argument, negated) for a SecLang operator string."""
+    text = text.strip()
+    negated = False
+    if text.startswith("!"):
+        negated = True
+        text = text[1:].lstrip()
+    m = re.match(r"@(\w+)\s*(.*)", text, re.DOTALL)
+    if m:
+        return m.group(1), m.group(2), negated
+    return "", text, negated  # implicit @rx
+
+
+def parse_seclang(text: str, source_file: str) -> List[SecRule]:
+    """Parse the SecRule directives in a .conf file, grouping chained rules."""
+    rules: List[SecRule] = []
+    pending_chain: Optional[SecRule] = None  # the rule whose ``chain`` is still open
+    for number, line in join_continuations(text):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        try:
+            tokens = tokenize_directive(stripped)
+        except SecLangError as exc:
+            raise SecLangError(f"{source_file}:{number}: {exc}") from exc
+        if not tokens or tokens[0] != "SecRule":
+            # SecAction, SecMarker, SecRuleEngine, SecComponentSignature, …
+            # carry no detection logic this engine can use.
+            continue
+        if len(tokens) < 3:
+            raise SecLangError(f"{source_file}:{number}: SecRule needs variables and an operator")
+        operator, argument, negated = parse_operator(tokens[2])
+        actions = split_actions(tokens[3]) if len(tokens) > 3 else []
+        rule = SecRule(
+            file=source_file,
+            line=number,
+            variables=parse_variables(tokens[1]),
+            operator=operator,
+            argument=argument,
+            negated=negated,
+            actions=actions,
+        )
+        if pending_chain is not None:
+            root = pending_chain
+            root.children.append(rule)
+            pending_chain = root if rule.has_action("chain") else None
+            continue
+        rules.append(rule)
+        if rule.has_action("chain"):
+            pending_chain = rule
     return rules
 
+
+# --------------------------------------------------------------------------- #
+# Translation
+# --------------------------------------------------------------------------- #
+
+def load_data_file(path: str) -> List[str]:
+    phrases: List[str] = []
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            phrases.append(line)
+    return phrases
+
+
+def phrases_to_pattern(phrases: Iterable[str]) -> str:
+    """Turn a ``@pm`` phrase list into a case-insensitive RE2 alternation.
+
+    ``re.escape`` only escapes characters with regex meaning, and RE2 accepts a
+    backslash before any ASCII punctuation, so its output is valid RE2.
+
+    The phrases are sorted alphabetically on purpose: Go's regexp parser only
+    factors common prefixes out of *adjacent* alternatives, and that factoring
+    is what keeps a multi-thousand-entry list matchable. Emitting the same list
+    ordered by length was measured at 10-20x slower per request.
+    """
+    unique = sorted(set(phrases))
+    return "(?i)(?:" + "|".join(re.escape(p) for p in unique) + ")"
+
+
+def map_targets(variables: List[Variable]) -> Tuple[List[str], List[str], List[str]]:
+    """Return (targets, dropped_variable_descriptions, notes)."""
+    targets: List[str] = []
+    dropped: List[str] = []
+    notes: List[str] = []
+
+    def add(t: str) -> None:
+        if t not in targets:
+            targets.append(t)
+
+    for var in variables:
+        label = ("!" if var.negated else "&" if var.counted else "") + var.name + (
+            ":" + var.selector if var.selector else ""
+        )
+        if var.negated:
+            notes.append(f"exclusion {label} dropped (no per-value exclusions)")
+            continue
+        if var.counted:
+            dropped.append(label)
+            continue
+        if var.name not in VARIABLES:
+            dropped.append(label)
+            continue
+        mapping = VARIABLES[var.name]
+        if mapping is None:
+            dropped.append(label)
+            continue
+        if var.selector:
+            if var.name == "REQUEST_HEADERS" and var.selector.lower() == "host":
+                # Go's net/http moves the Host header to r.Host; the HEADERS:Host
+                # target would always be empty (and skip the rule).
+                add("HOST")
+                continue
+            base = SELECTOR_TARGETS.get(var.name)
+            is_regex = var.selector.startswith("/") and var.selector.endswith("/")
+            if base and not is_regex:
+                add(f"{base}:{var.selector}")
+                continue
+            # Regex selectors and selectors on collections without a dynamic
+            # target widen to the whole collection.
+            notes.append(f"{label} widened to {'/'.join(mapping)}")
+        for t in mapping:
+            add(t)
+    return targets, dropped, notes
+
+
+def map_transformations(names: List[str]) -> Tuple[Optional[List[str]], List[str], Optional[str]]:
+    """Return (chain, notes, unsupported_name).
+
+    ``unsupported_name`` is set when a step changes the value's meaning and the
+    rule must be skipped.
+    """
+    chain: List[str] = []
+    notes: List[str] = []
+    for raw in names:
+        key = raw.strip().lower()
+        if key == "none":
+            chain = []
+            continue
+        if key in ENGINE_TRANSFORMS:
+            chain.append(ENGINE_TRANSFORMS[key])
+            continue
+        kind, replacement = TRANSFORMATIONS.get(key, ("skip", None))
+        if kind == "approx":
+            chain.append(replacement)
+            notes.append(f"t:{raw} approximated by {replacement}")
+        elif kind == "drop":
+            notes.append(f"t:{raw} dropped (not implemented)")
+        else:
+            return None, notes, raw
+    deduped: List[str] = []
+    for step in chain:
+        if not deduped or deduped[-1] != step:
+            deduped.append(step)
+    return deduped, notes, None
+
+
+def relax_anchors(pattern: str, targets: List[str]) -> Tuple[str, Optional[str]]:
+    """Rewrite a leading ``^`` / trailing ``$`` for collection targets (see COLLECTION_TARGETS)."""
+    if not any(t in COLLECTION_TARGETS for t in targets):
+        return pattern, None
+    flags = ""
+    m = LEADING_FLAGS.match(pattern)
+    if m:
+        flags, pattern = m.group(0), pattern[m.end():]
+    changed = []
+    if pattern.startswith("^"):
+        pattern = RELAXED_START + pattern[1:]
+        changed.append("^")
+    if pattern.endswith("$") and not pattern.endswith("\\$") and not pattern.endswith("[$"):
+        pattern = pattern[:-1] + RELAXED_END
+        changed.append("$")
+    if not changed:
+        return flags + pattern, None
+    return flags + pattern, "anchor " + " and ".join(changed) + " relaxed to member boundaries (collection targets)"
+
+
+def python_heuristic_failures(entries: List[Tuple[str, str]]) -> Dict[str, str]:
+    """Best-effort stand-in for RE2 when Go is unavailable (lookaround, backrefs, \\R …)."""
+    failures: Dict[str, str] = {}
+    for rule_id, pattern in entries:
+        m = PCRE_ONLY.search(pattern)
+        if m:
+            failures[rule_id] = f"PCRE-only construct {m.group(0)!r} (Python heuristic)"
+    return failures
+
+
+def re2_validate(entries: List[Tuple[str, str]], mode: str, repo_root: str) -> Dict[str, str]:
+    """Return {id: error} for the patterns RE2 rejects."""
+    failures: Dict[str, str] = {}
+    if not entries:
+        return failures
+    if mode == "python":
+        return python_heuristic_failures(entries)
+    remaining = [{"id": i, "pattern": p} for i, p in entries]
+    try:
+        proc = subprocess.run(
+            ["go", "run", "./tools/re2check"],
+            input=json.dumps(remaining).encode("utf-8"),
+            capture_output=True,
+            cwd=repo_root,
+            check=False,
+        )
+    except FileNotFoundError:
+        if mode == "go":
+            raise SystemExit("re2check: the go toolchain is not installed; pass --re2check python to skip RE2 validation")
+        print("warning: go not found; falling back to the Python syntax heuristic (patterns are NOT RE2-validated)", file=sys.stderr)
+        return python_heuristic_failures(entries)
+    if proc.returncode != 0:
+        raise SystemExit(f"re2check failed:\n{proc.stderr.decode('utf-8', 'replace')}")
+    failures.update(json.loads(proc.stdout.decode("utf-8")))
+    return failures
+
+
+def translate_rule(rule: SecRule, data_dir: str) -> Tuple[Optional[Translated], Optional[Skipped]]:
+    rule_id = rule.id
+    source = os.path.basename(rule.file)
+    if rule_id is None:
+        return None, None  # anonymous rules carry no detection logic
+    skip = lambda category, detail="": (None, Skipped(rule_id, source, category, detail))  # noqa: E731
+
+    if rule.children:
+        return skip("chained rule", "caddy-waf has no rule chaining")
+    severity = (rule.first_action("severity") or "").upper()
+    if rule.has_action("skipAfter") or not severity:
+        return skip("control/flow rule", "no severity")
+    if rule.negated:
+        return skip("negated operator", f"!@{rule.operator or 'rx'}")
+    operator = rule.operator or "rx"
+    if operator not in REGEX_OPERATORS:
+        return skip("non-regex operator", f"@{operator}")
+
+    if operator == "rx":
+        pattern = rule.argument
+        if "%{" in pattern:
+            return skip("macro expansion", "pattern uses %{…}")
+        if re.fullmatch(r"\^\s*\$", pattern):
+            # caddy-waf skips a rule when the target is missing or empty, so an
+            # "is empty" presence check can never fire (see dead_rules_test.go).
+            return skip("presence check", "^$ never evaluated: empty targets skip the rule")
+    elif operator == "pm":
+        pattern = phrases_to_pattern(rule.argument.split())
+    else:
+        path = os.path.join(data_dir, rule.argument.strip())
+        if not os.path.isfile(path):
+            return skip("data file not found", rule.argument.strip())
+        pattern = phrases_to_pattern(load_data_file(path))
+    if not pattern:
+        return skip("empty pattern")
+
+    targets, dropped_vars, notes = map_targets(rule.variables)
+    if not targets:
+        return skip("no mappable target", "|".join(dropped_vars or ["(none)"]))
+    for label in dropped_vars:
+        notes.append(f"variable {label} dropped (no caddy-waf equivalent)")
+    if operator == "rx":
+        pattern, anchor_note = relax_anchors(pattern, targets)
+        if anchor_note:
+            notes.append(anchor_note)
+
+    chain, t_notes, unsupported = map_transformations(rule.action_values("t"))
+    notes.extend(t_notes)
+    if unsupported:
+        return skip("unsupported transformation", f"t:{unsupported} changes the value's meaning")
+    assert chain is not None
+    if any(t in RAW_TARGETS for t in targets) and "urlDecodeUni" not in chain and "urlDecode" not in chain:
+        # ModSecurity hands CRS an already-decoded ARGS; caddy-waf's ARGS/BODY/URI
+        # are raw, so decode first to match the same text the rule was written for.
+        chain.insert(0, "urlDecodeUni")
+
+    score = SEVERITY_SCORE.get(severity)
+    if score is None:
+        return skip("unknown severity", severity)
+
+    phase = int(rule.first_action("phase") or 2)
+    if phase not in (1, 2, 3, 4):
+        return skip("invalid phase", str(phase))
+    if any(t.startswith("RESPONSE_") for t in targets) and phase < 3:
+        phase = 4
+        notes.append("phase moved to 4 (response targets)")
+
+    msg = rule.first_action("msg") or "No description provided"
+    pl = rule.paranoia_level
+    out: "OrderedDict[str, object]" = OrderedDict()
+    out["id"] = f"crs-{rule_id}"
+    out["phase"] = phase
+    out["pattern"] = pattern
+    out["targets"] = targets
+    out["severity"] = severity
+    out["action"] = "log"
+    out["score"] = score
+    out["description"] = f"OWASP CRS {rule_id} PL{pl}: {msg}"
+    out["transformations"] = chain
+    return Translated(out, pl, notes, source), None
+
+
+def translate_directory(
+    rules_dir: str,
+    re2_mode: str,
+    repo_root: str,
+    tuning: Optional[Tuning] = None,
+) -> Tuple[List[Translated], List[Skipped], Counter]:
+    tuning = tuning or Tuning()
+    translated: List[Translated] = []
+    skipped: List[Skipped] = []
+    seen_ids: Dict[str, str] = {}
+    totals: Counter = Counter()
+    for name in sorted(os.listdir(rules_dir)):
+        if not name.endswith(".conf"):
+            continue
+        path = os.path.join(rules_dir, name)
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            rules = parse_seclang(fh.read(), path)
+        for rule in rules:
+            if rule.id is None:
+                continue
+            totals[name] += 1
+            if rule.id in tuning.remove:
+                skipped.append(Skipped(rule.id, name, "removed by tuning", tuning.remove[rule.id]))
+                continue
+            if rule.id in seen_ids:
+                skipped.append(Skipped(rule.id, name, "duplicate id", f"already defined in {seen_ids[rule.id]}"))
+                continue
+            seen_ids[rule.id] = name
+            result, skip = translate_rule(rule, rules_dir)
+            if result and rule.id in tuning.remove_targets:
+                for target, reason in tuning.remove_targets[rule.id].items():
+                    if target in result.rule["targets"]:
+                        result.rule["targets"].remove(target)
+                        result.notes.append(f"target {target} removed by tuning: {reason}")
+                if not result.rule["targets"]:
+                    skip, result = Skipped(rule.id, name, "removed by tuning", "every target removed"), None
+            if skip:
+                skipped.append(skip)
+            elif result:
+                translated.append(result)
+
+    failures = re2_validate([(t.rule["id"], t.rule["pattern"]) for t in translated], re2_mode, repo_root)
+    if failures:
+        kept: List[Translated] = []
+        for t in translated:
+            err = failures.get(t.rule["id"])
+            if err is None:
+                kept.append(t)
+            else:
+                skipped.append(Skipped(t.rule["id"][len("crs-"):], t.source_file, "RE2 rejects the pattern", err))
+        translated = kept
+    skipped.sort(key=lambda s: (s.source_file, s.id))
+    return translated, skipped, totals
+
+
+# --------------------------------------------------------------------------- #
+# Output
+# --------------------------------------------------------------------------- #
+
+def apply_block_severity(translated: List[Translated], block_severity: Optional[str]) -> None:
+    if not block_severity:
+        return
+    threshold = SEVERITY_ORDER.index(block_severity.upper())
+    for t in translated:
+        if SEVERITY_ORDER.index(t.rule["severity"]) >= threshold:
+            t.rule["action"] = "block"
+
+
+def is_request_phase(phase: int) -> bool:
+    return phase in (1, 2)
+
+
+def is_response_phase(phase: int) -> bool:
+    return phase in (3, 4)
+
+
+def write_bundle(path: str, rules: List[OrderedDict]) -> None:
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(rules, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+
+def write_report(
+    path: str,
+    ref: str,
+    translated: List[Translated],
+    skipped: List[Skipped],
+    totals: Counter,
+    outputs: Dict[str, int],
+) -> None:
+    by_file_emitted: Counter = Counter(t.source_file for t in translated)
+    by_file_skipped: Counter = Counter(s.source_file for s in skipped)
+    reasons: Counter = Counter(s.category for s in skipped)
+    by_pl: Counter = Counter(t.paranoia_level for t in translated)
+
+    lines: List[str] = []
+    lines.append(f"# OWASP CRS {ref} translation coverage")
+    lines.append("")
+    lines.append(
+        "Generated by `get_owasp_rules.py`. caddy-waf ports the `@rx`/`@pm` subset of "
+        "the Core Rule Set that fits its one-regex-per-target model; this report "
+        "lists what was ported, what was skipped and why, and which ported rules "
+        "lost a transformation or an exclusion on the way. **This is CRS-informed "
+        "coverage, not CRS parity.**"
+    )
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    total_rules = sum(totals.values())
+    lines.append(f"- CRS rules with an id: {total_rules}")
+    lines.append(f"- Ported: {len(translated)} (" + ", ".join(f"PL{pl}: {n}" for pl, n in sorted(by_pl.items())) + ")")
+    lines.append(f"- Skipped: {len(skipped)}")
+    for name, count in outputs.items():
+        lines.append(f"- `{os.path.basename(name)}`: {count} rules")
+    lines.append("")
+    lines.append("### Skip reasons")
+    lines.append("")
+    lines.append("| Reason | Rules |")
+    lines.append("|---|---:|")
+    for reason, count in reasons.most_common():
+        lines.append(f"| {reason} | {count} |")
+    lines.append("")
+    lines.append("### Per file")
+    lines.append("")
+    lines.append("| CRS file | Rules | Ported | Skipped |")
+    lines.append("|---|---:|---:|---:|")
+    for name in sorted(totals):
+        lines.append(f"| {name} | {totals[name]} | {by_file_emitted[name]} | {by_file_skipped[name]} |")
+    lines.append("")
+    lines.append("## What the port cannot express")
+    lines.append("")
+    lines.append(
+        "- **Chained rules.** A `chain` narrows a match with a second condition "
+        "(a count, a transaction variable, a second regex). caddy-waf evaluates "
+        "each rule independently, so chained rules are skipped rather than "
+        "ported without their narrowing condition."
+    )
+    lines.append(
+        "- **Non-regex operators.** `@detectSQLi`/`@detectXSS` (libinjection), "
+        "`@validateByteRange`, `@validateUrlEncoding`, `@eq`/`@lt`/`@ge`, "
+        "`@ipMatch`, `@streq`, `@within` and `@endsWith` have no regex "
+        "equivalent."
+    )
+    lines.append(
+        "- **Structured request parsing.** ModSecurity matches `ARGS` against each "
+        "decoded parameter value and `XML:/*` against parsed XML nodes; caddy-waf "
+        "matches the raw query string and raw body, so a pattern can also see "
+        "parameter names, JSON syntax and multipart framing. `ARGS` is emitted as "
+        "`ARGS` + `BODY`; `XML` as `BODY`."
+    )
+    lines.append(
+        "- **Exclusions and counts.** `!REQUEST_COOKIES:/__utm/`-style exclusions "
+        "and `&ARGS` counts are dropped; the rule still applies to the whole "
+        "collection."
+    )
+    lines.append(
+        "- **Transformations.** `cmdLine`, `normalizePath`, `jsDecode`, "
+        "`cssDecode`, `utf8toUnicode` and `escapeSeqDecode` are not implemented "
+        "and are dropped (the raw value is still matched, so this only loses "
+        "evasion coverage). `removeWhitespace` and `removeComments` are "
+        "approximated by `compressWhitespace` and `replaceComments`. Rules that "
+        "need `length`, `base64Decode`, `hexDecode`, `sha1` or `urlEncode` "
+        "are skipped because those change what the pattern is matched against."
+    )
+    lines.append(
+        "- **Anchors.** ModSecurity matches each parameter, header and cookie "
+        "value on its own; caddy-waf matches the raw query string, raw body, "
+        "and the joined header/cookie lists. A leading `^` or trailing `$` in a "
+        "rule on those targets is rewritten to a member boundary "
+        "(`(?:^|[&=\"]|:\\s*)` / `(?:$|[&;\"])`) so the rule can still match a "
+        "value that is not the first or last one. Affected rules are listed "
+        "below."
+    )
+    lines.append(
+        "- **Tuning.** `rules/crs/tuning.txt` removes a target from rules that "
+        "cannot be applied to a raw body without matching ordinary JSON, YAML "
+        "or multipart framing; the reason is recorded per rule below. This is "
+        "the caddy-waf equivalent of a CRS `SecRuleUpdateTargetById` exclusion."
+    )
+    lines.append(
+        "- **Paranoia levels and scoring.** The `paranoia-level/N` tag is recorded "
+        "in each rule's description and used to split the output files; there "
+        "is no runtime paranoia-level switch. Scores follow CRS severities "
+        "(CRITICAL 5, ERROR 4, WARNING 3, NOTICE 2). Every rule is `log`, "
+        "which is advisory unless `log_scores_block` is set."
+    )
+    lines.append("")
+    lines.append("## Ported rules with a lossy translation")
+    lines.append("")
+    lossy = [t for t in translated if t.notes]
+    if lossy:
+        lines.append("| Rule | File | Notes |")
+        lines.append("|---|---|---|")
+        for t in lossy:
+            lines.append(f"| {t.rule['id']} | {t.source_file} | {'; '.join(t.notes)} |")
+    else:
+        lines.append("None.")
+    lines.append("")
+    lines.append("## Skipped rules")
+    lines.append("")
+    lines.append("| CRS id | File | Reason |")
+    lines.append("|---|---|---|")
+    for s in skipped:
+        reason = s.reason.replace("|", "\\|")
+        lines.append(f"| {s.id} | {s.source_file} | {reason} |")
+    lines.append("")
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(lines))
+
+
+# --------------------------------------------------------------------------- #
+# Source acquisition
+# --------------------------------------------------------------------------- #
+
+def download_crs(ref: str, dest: str) -> str:
+    """Download the CRS tarball for ``ref`` and return the extracted rules dir."""
+    url = f"https://github.com/{CRS_REPO}/archive/refs/tags/{ref}.tar.gz"
+    print(f"Downloading {url}")
+    with urllib.request.urlopen(url) as resp:  # noqa: S310 - fixed GitHub URL
+        data = resp.read()
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+        members = [m for m in tar.getmembers() if "/rules/" in m.name and m.isfile()]
+        if not members:
+            raise SystemExit("archive contains no rules/ directory")
+        for m in members:
+            # Flatten to dest/rules/<name>; the archive root is coreruleset-<ver>/.
+            m.name = "rules/" + m.name.split("/rules/", 1)[1]
+            if ".." in m.name.split("/"):
+                continue
+            tar.extract(m, dest)
+    return os.path.join(dest, "rules")
+
+
+@dataclass
+class Tuning:
+    """Per-rule adjustments, the caddy-waf equivalent of CRS ``SecRuleRemoveById``
+    and ``SecRuleUpdateTargetById`` exclusions."""
+    remove: Dict[str, str] = field(default_factory=dict)  # id -> reason
+    remove_targets: Dict[str, Dict[str, str]] = field(default_factory=dict)  # id -> {target: reason}
+
+
+def read_tuning(path: Optional[str], inline_exclude: Optional[str]) -> Tuning:
+    """Parse a tuning file.
+
+    One directive per line, ``#`` starts a comment (the comment is kept as the
+    reason in the coverage report)::
+
+        942190 remove-target BODY   # quote-prefixed keyword branch matches JSON keys
+        920350 remove               # Host is an IP on purpose in this deployment
+    """
+    tuning = Tuning()
+    if inline_exclude:
+        for rule_id in inline_exclude.split(","):
+            if rule_id.strip():
+                tuning.remove[rule_id.strip()] = "listed in --exclude"
+    if not path:
+        return tuning
+    with open(path, encoding="utf-8") as fh:
+        for number, raw in enumerate(fh, 1):
+            text, _, comment = raw.partition("#")
+            words = text.split()
+            if not words:
+                continue
+            reason = comment.strip() or f"{os.path.basename(path)}:{number}"
+            rule_id = words[0]
+            directive = words[1] if len(words) > 1 else "remove"
+            if directive == "remove" and len(words) <= 2:
+                tuning.remove[rule_id] = reason
+            elif directive == "remove-target" and len(words) == 3:
+                for target in words[2].split(","):
+                    tuning.remove_targets.setdefault(rule_id, {})[target.strip().upper()] = reason
+            else:
+                raise SystemExit(f"{path}:{number}: expected '<id> remove' or '<id> remove-target <TARGET[,TARGET]>'")
+    return tuning
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    src = parser.add_mutually_exclusive_group()
+    src.add_argument("--source", help="local CRS rules/ directory (skips the download)")
+    src.add_argument("--ref", default=DEFAULT_REF, help=f"CRS git tag to download (default {DEFAULT_REF})")
+    out = parser.add_mutually_exclusive_group()
+    out.add_argument("--output-dir", help="write one request bundle per paranoia level (crs-pl1.json … crs-pl4.json) "
+                     "plus the response-phase rules as crs-plN-response.json")
+    out.add_argument("--output", help="write one cumulative request bundle up to --paranoia-level; the response-phase "
+                     "rules go to <name>-response.json next to it")
+    parser.add_argument("--paranoia-level", type=int, default=1, choices=[1, 2, 3, 4],
+                        help="highest paranoia level to include in --output (default 1)")
+    parser.add_argument("--report", help="coverage report path (default: COVERAGE.md next to the output)")
+    parser.add_argument("--exclude", help="comma-separated CRS ids to leave out")
+    parser.add_argument("--tuning", help="tuning file: '<id> remove' or '<id> remove-target <TARGET>' per line, # comments")
+    parser.add_argument("--block-severity", choices=SEVERITY_ORDER,
+                        help="emit action \"block\" for rules at or above this severity (default: all \"log\")")
+    parser.add_argument("--re2check", choices=["auto", "go", "python"], default="auto",
+                        help="pattern validator: go (require the Go helper), python (syntax heuristic only), auto")
+    args = parser.parse_args(argv)
+
+    if not args.output_dir and not args.output:
+        args.output_dir = "rules/crs"
+    repo_root = os.path.dirname(os.path.abspath(__file__))
+    ref = args.ref if not args.source else os.path.basename(os.path.dirname(os.path.abspath(args.source))) or "local"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        rules_dir = args.source or download_crs(args.ref, tmp)
+        tuning = read_tuning(args.tuning, args.exclude)
+        translated, skipped, totals = translate_directory(rules_dir, args.re2check, repo_root, tuning)
+
+    apply_block_severity(translated, args.block_severity)
+    translated.sort(key=lambda t: t.rule["id"])
+
+    outputs: Dict[str, int] = {}
+    if args.output_dir:
+        for pl in (1, 2, 3, 4):
+            selected = [t for t in translated if t.paranoia_level == pl]
+            for suffix, phase_ok in (("", is_request_phase), ("-response", is_response_phase)):
+                rules = [t.rule for t in selected if phase_ok(t.rule["phase"])]
+                if not rules and suffix:
+                    continue
+                path = os.path.join(args.output_dir, f"crs-pl{pl}{suffix}.json")
+                write_bundle(path, rules)
+                outputs[path] = len(rules)
+        report = args.report or os.path.join(args.output_dir, "COVERAGE.md")
+    else:
+        selected = [t for t in translated if t.paranoia_level <= args.paranoia_level]
+        base, ext = os.path.splitext(args.output)
+        for suffix, phase_ok in (("", is_request_phase), ("-response", is_response_phase)):
+            rules = [t.rule for t in selected if phase_ok(t.rule["phase"])]
+            if not rules and suffix:
+                continue
+            path = base + suffix + ext
+            write_bundle(path, rules)
+            outputs[path] = len(rules)
+        report = args.report or os.path.join(os.path.dirname(args.output) or ".", "COVERAGE.md")
+
+    write_report(report, ref, translated, skipped, totals, outputs)
+    for name, count in outputs.items():
+        print(f"wrote {count} rules to {name}")
+    print(f"ported {len(translated)} of {sum(totals.values())} CRS rules; {len(skipped)} skipped (see {report})")
+    return 0
+
+
 if __name__ == "__main__":
-    # Configuration for downloading OWASP Core Rule Set
-    repo_url = "coreruleset/coreruleset"
-    rules_dir = "rules"
-    output_path = "rules.json"
-    
-    download_owasp_rules(repo_url, rules_dir, output_path)
+    sys.exit(main())

--- a/get_owasp_rules.py
+++ b/get_owasp_rules.py
@@ -623,6 +623,19 @@ def re2_validate(entries: List[Tuple[str, str]], mode: str, repo_root: str) -> D
     if mode == "python":
         return python_heuristic_failures(entries)
     remaining = [{"id": i, "pattern": p} for i, p in entries]
+
+    def fallback(problem: str) -> Dict[str, str]:
+        # ``auto`` degrades to the heuristic (e.g. the script was copied out of
+        # the repository, or Go is not installed); ``go`` is a hard requirement.
+        if mode == "go":
+            raise SystemExit(f"re2check: {problem}; pass --re2check python to skip RE2 validation")
+        print(f"warning: {problem}; falling back to the Python syntax heuristic (patterns are NOT RE2-validated)",
+              file=sys.stderr)
+        return python_heuristic_failures(entries)
+
+    helper = os.path.join(repo_root, "tools", "re2check", "main.go")
+    if not os.path.isfile(helper):
+        return fallback(f"{helper} not found")
     try:
         proc = subprocess.run(
             ["go", "run", "./tools/re2check"],
@@ -632,12 +645,9 @@ def re2_validate(entries: List[Tuple[str, str]], mode: str, repo_root: str) -> D
             check=False,
         )
     except FileNotFoundError:
-        if mode == "go":
-            raise SystemExit("re2check: the go toolchain is not installed; pass --re2check python to skip RE2 validation")
-        print("warning: go not found; falling back to the Python syntax heuristic (patterns are NOT RE2-validated)", file=sys.stderr)
-        return python_heuristic_failures(entries)
+        return fallback("the go toolchain is not installed")
     if proc.returncode != 0:
-        raise SystemExit(f"re2check failed:\n{proc.stderr.decode('utf-8', 'replace')}")
+        return fallback("go run ./tools/re2check failed: " + proc.stderr.decode("utf-8", "replace").strip())
     failures.update(json.loads(proc.stdout.decode("utf-8")))
     return failures
 
@@ -792,6 +802,10 @@ def apply_block_severity(translated: List[Translated], block_severity: Optional[
             t.rule["action"] = "block"
 
 
+def plural(count: int, noun: str) -> str:
+    return f"{count} {noun}" if count == 1 else f"{count} {noun}s"
+
+
 def is_request_phase(phase: int) -> bool:
     return phase in (1, 2)
 
@@ -814,6 +828,7 @@ def write_report(
     skipped: List[Skipped],
     totals: Counter,
     outputs: Dict[str, int],
+    tuning_path: Optional[str] = None,
 ) -> None:
     by_file_emitted: Counter = Counter(t.source_file for t in translated)
     by_file_skipped: Counter = Counter(s.source_file for s in skipped)
@@ -838,7 +853,7 @@ def write_report(
     lines.append(f"- Ported: {len(translated)} (" + ", ".join(f"PL{pl}: {n}" for pl, n in sorted(by_pl.items())) + ")")
     lines.append(f"- Skipped: {len(skipped)}")
     for name, count in outputs.items():
-        lines.append(f"- `{os.path.basename(name)}`: {count} rules")
+        lines.append(f"- `{os.path.basename(name)}`: {plural(count, 'rule')}")
     lines.append("")
     lines.append("### Skip reasons")
     lines.append("")
@@ -898,11 +913,13 @@ def write_report(
         "value that is not the first or last one. Affected rules are listed "
         "below."
     )
+    tuning_source = f"`{os.path.basename(tuning_path)}` (passed with `--tuning`)" if tuning_path else "a `--tuning` file"
     lines.append(
-        "- **Tuning.** `rules/crs/tuning.txt` removes a target from rules that "
-        "cannot be applied to a raw body without matching ordinary JSON, YAML "
-        "or multipart framing; the reason is recorded per rule below. This is "
-        "the caddy-waf equivalent of a CRS `SecRuleUpdateTargetById` exclusion."
+        f"- **Tuning.** {tuning_source} can remove a rule, or remove one target "
+        "from a rule that cannot be applied to a raw body without matching "
+        "ordinary JSON, YAML or multipart framing; the reason is recorded per "
+        "rule below. This is the caddy-waf equivalent of the CRS "
+        "`SecRuleRemoveById` / `SecRuleUpdateTargetById` exclusions."
     )
     lines.append(
         "- **Paranoia levels and scoring.** The `paranoia-level/N` tag is recorded "
@@ -1060,9 +1077,9 @@ def main(argv: Optional[List[str]] = None) -> int:
             outputs[path] = len(rules)
         report = args.report or os.path.join(os.path.dirname(args.output) or ".", "COVERAGE.md")
 
-    write_report(report, ref, translated, skipped, totals, outputs)
+    write_report(report, ref, translated, skipped, totals, outputs, args.tuning)
     for name, count in outputs.items():
-        print(f"wrote {count} rules to {name}")
+        print(f"wrote {plural(count, 'rule')} to {name}")
     print(f"ported {len(translated)} of {sum(totals.values())} CRS rules; {len(skipped)} skipped (see {report})")
     return 0
 

--- a/rules/README.md
+++ b/rules/README.md
@@ -38,9 +38,19 @@ engine), not the ModSecurity operator set. That means:
 sets) under RE2 and rejects duplicate IDs, so a broken bundle fails CI rather than
 shipping inert.
 
-## SpiderLabs / OWASP-CRS
+## OWASP CRS
 
-A raw ModSecurity CRS export is **not** RE2-loadable as-is. Generate an
-RE2-compatible subset with [`get_spiderlabs_rules.py`](../get_spiderlabs_rules.py)
-(keeps `@rx` regex rules only) or [`get_owasp_rules.py`](../get_owasp_rules.py), then
-point `rule_file` at the output.
+A raw ModSecurity CRS export is **not** RE2-loadable as-is (operators, chained
+rules, `t:` names and per-parameter anchors all differ). Generate a loadable,
+RE2-validated subset with [`get_owasp_rules.py`](../get_owasp_rules.py), which
+ports the `@rx`/`@pm`/`@pmFromFile` rules and writes a coverage report of what
+it had to skip:
+
+```bash
+python3 get_owasp_rules.py --ref v4.9.0 --output-dir rules/crs
+```
+
+See [docs/scripts.md](../docs/scripts.md#get_owasp_rulespy) for the options.
+[`get_spiderlabs_rules.py`](../get_spiderlabs_rules.py) is the older, cruder
+converter for the SpiderLabs rule set (keeps `@rx` rules only, validates with
+Python's `re`, not RE2).

--- a/test_get_owasp_rules.py
+++ b/test_get_owasp_rules.py
@@ -279,6 +279,16 @@ class TranslationTests(unittest.TestCase):
         failures = owasp.re2_validate([("ok", r"(?i)a|b"), ("look", r"a(?=b)"), ("big", r"a{1001}")], "go", REPO_ROOT)
         self.assertEqual(sorted(failures), ["big", "look"])
 
+    def test_auto_mode_falls_back_without_the_helper(self):
+        with contextlib.redirect_stderr(io.StringIO()) as err:
+            failures = owasp.re2_validate([("look", r"a(?=b)"), ("ok", "a")], "auto", self.tmp)
+        self.assertEqual(sorted(failures), ["look"])
+        self.assertIn("falling back", err.getvalue())
+
+    def test_go_mode_requires_the_helper(self):
+        with self.assertRaises(SystemExit):
+            owasp.re2_validate([("ok", "a")], "go", self.tmp)
+
     def test_report(self):
         translated, skipped, totals = self.translate()
         report = os.path.join(self.tmp, "COVERAGE.md")
@@ -287,6 +297,10 @@ class TranslationTests(unittest.TestCase):
         self.assertIn("# OWASP CRS v0-test translation coverage", text)
         self.assertIn("- CRS rules with an id: 13", text)
         self.assertIn("`crs-pl1.json`: 4 rules", text)
+        owasp.write_report(report, "v0-test", translated, skipped, totals, {"one.json": 1}, "my-tuning.txt")
+        text = open(report).read()
+        self.assertIn("`one.json`: 1 rule\n", text)
+        self.assertIn("`my-tuning.txt` (passed with `--tuning`)", text)
         self.assertIn("| chained rule | 1 |", text)
         self.assertIn("| 920170 | sample.conf | chained rule: caddy-waf has no rule chaining |", text)
         self.assertIn("| crs-942200 | sample.conf |", text)

--- a/test_get_owasp_rules.py
+++ b/test_get_owasp_rules.py
@@ -240,18 +240,29 @@ class TranslationTests(unittest.TestCase):
     def test_tuning(self):
         path = os.path.join(self.tmp, "tuning.txt")
         with open(path, "w") as fh:
-            fh.write("942100 remove-target BODY,COOKIES  # raw body\n913100 remove  # noisy\n931100\n")
+            fh.write("942100 remove-target body,COOKIES  # raw body\n913100 remove  # noisy\n931100\n"
+                     "950100 remove-target response_body  # selector-free\n")
         tuning = owasp.read_tuning(path, "920350")
         translated, skipped, _ = self.translate(tuning)
         ported = {t.rule["id"]: t for t in translated}
-        self.assertEqual(sorted(ported), ["crs-942100", "crs-942200", "crs-950100"])
+        self.assertEqual(sorted(ported), ["crs-942100", "crs-942200"])
         self.assertEqual(ported["crs-942100"].rule["targets"], ["ARGS"])
+        self.assertEqual({s.id: s.detail for s in skipped}["950100"], "every target removed")
         self.assertTrue(any("target BODY removed by tuning: raw body" in n for n in ported["crs-942100"].notes))
         by_id = {s.id: s for s in skipped}
         self.assertEqual(by_id["913100"].category, "removed by tuning")
         self.assertEqual(by_id["913100"].detail, "noisy")
         self.assertEqual(by_id["920350"].detail, "listed in --exclude")
         self.assertEqual(by_id["931100"].category, "removed by tuning")
+
+    def test_tuning_keeps_selector_case(self):
+        path = os.path.join(self.tmp, "tuning.txt")
+        with open(path, "w") as fh:
+            fh.write("913100 remove-target headers:User-Agent\n")
+        tuning = owasp.read_tuning(path, None)
+        self.assertEqual(tuning.remove_targets["913100"], {"HEADERS:User-Agent": "tuning.txt:1"})
+        _, skipped, _ = self.translate(tuning)
+        self.assertEqual({s.id: s.category for s in skipped}["913100"], "removed by tuning")
 
     def test_tuning_syntax_error(self):
         path = os.path.join(self.tmp, "tuning.txt")

--- a/test_get_owasp_rules.py
+++ b/test_get_owasp_rules.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Unit tests for get_owasp_rules.py (run: python3 -m unittest test_get_owasp_rules).
+
+No network access and no Go toolchain needed: the translation tests use the
+Python heuristic validator (``--re2check python``); the one test that needs
+RE2 is skipped when ``go`` is not on PATH.
+"""
+
+import contextlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import get_owasp_rules as owasp  # noqa: E402
+
+REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
+
+SAMPLE_CONF = r'''
+# A comment line and a SecAction that must be ignored.
+SecAction "id:900000,phase:1,pass,nolog,setvar:tx.paranoia_level=1"
+
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 1" "id:942011,phase:1,pass,nolog,skipAfter:END"
+
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "@rx (?i)union\s+select" \
+    "id:942100,\
+    phase:2,\
+    block,\
+    t:none,t:utf8toUnicode,t:urlDecodeUni,t:removeNulls,\
+    msg:'SQL Injection Attack, with a comma',\
+    tag:'attack-sqli',\
+    tag:'paranoia-level/1',\
+    severity:'CRITICAL',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}'"
+
+SecRule REQUEST_HEADERS:User-Agent "@pmFromFile scanners.data" \
+    "id:913100,phase:1,block,t:none,msg:'Scanner',tag:'paranoia-level/1',severity:'CRITICAL'"
+
+SecRule ARGS "@rx ^https?://\d+\.\d+$" \
+    "id:931100,phase:2,block,t:none,msg:'RFI',tag:'paranoia-level/2',severity:'CRITICAL'"
+
+SecRule REQUEST_HEADERS:Host "@rx ^[\d.:]+$" \
+    "id:920350,phase:1,block,t:none,msg:'Host is IP',tag:'paranoia-level/1',severity:'WARNING'"
+
+SecRule REQUEST_HEADERS:Host "@rx ^$" \
+    "id:920290,phase:1,block,t:none,msg:'Empty Host',severity:'WARNING'"
+
+SecRule ARGS "@rx a" "id:920170,phase:2,block,chain,msg:'Chained parent',severity:'CRITICAL'"
+    SecRule REQUEST_HEADERS:Content-Length "!@rx ^0?$" "t:none"
+
+SecRule ARGS "@detectSQLi" "id:942101,phase:2,block,msg:'libinjection',severity:'CRITICAL'"
+
+SecRule ARGS "@rx x" "id:934100,phase:2,block,t:base64Decode,msg:'needs decode',severity:'CRITICAL'"
+
+SecRule ARGS "@rx ^(?:%{tx.allowed})$" "id:920420,phase:1,block,msg:'macro',severity:'CRITICAL'"
+
+SecRule TX:1 "@rx y" "id:942999,phase:2,block,msg:'no target',severity:'CRITICAL'"
+
+SecRule RESPONSE_BODY "@pm password root" \
+    "id:950100,phase:4,block,t:none,msg:'Leak with \"escaped quote\" in msg',severity:'ERROR'"
+
+SecRule ARGS "@rx (?i)ab[\"']c" "id:942200,phase:2,block,t:none,t:lowercase,t:removeWhitespace,t:cmdLine,msg:'Quote',severity:'NOTICE'"
+'''
+
+
+class ParserTests(unittest.TestCase):
+    def setUp(self):
+        self.rules = owasp.parse_seclang(SAMPLE_CONF, "sample.conf")
+        self.by_id = {r.id: r for r in self.rules}
+
+    def test_continuations_and_comments(self):
+        # 14 SecRule directives, 1 of them a chain child folded into its parent.
+        self.assertEqual(len(self.rules), 13)
+        self.assertNotIn(None, self.by_id)
+
+    def test_actions_split_outside_quotes(self):
+        r = self.by_id["942100"]
+        self.assertEqual(r.first_action("msg"), "SQL Injection Attack, with a comma")
+        self.assertEqual(r.action_values("t"), ["none", "utf8toUnicode", "urlDecodeUni", "removeNulls"])
+        self.assertEqual(r.action_values("tag"), ["attack-sqli", "paranoia-level/1"])
+        self.assertEqual(r.paranoia_level, 1)
+        self.assertEqual(r.first_action("severity"), "CRITICAL")
+        self.assertEqual(r.first_action("phase"), "2")
+
+    def test_variables(self):
+        names = [(v.name, v.selector, v.negated) for v in self.by_id["942100"].variables]
+        self.assertEqual(names, [
+            ("REQUEST_COOKIES", None, False),
+            ("REQUEST_COOKIES", "/__utm/", True),
+            ("REQUEST_COOKIES_NAMES", None, False),
+            ("ARGS_NAMES", None, False),
+            ("ARGS", None, False),
+            ("XML", "/*", False),
+        ])
+
+    def test_operator_parsing(self):
+        self.assertEqual(self.by_id["942100"].operator, "rx")
+        self.assertEqual(self.by_id["942100"].argument, r"(?i)union\s+select")
+        self.assertEqual(self.by_id["913100"].operator, "pmFromFile")
+        self.assertEqual(self.by_id["942101"].operator, "detectSQLi")
+
+    def test_chain_grouping(self):
+        parent = self.by_id["920170"]
+        self.assertEqual(len(parent.children), 1)
+        child = parent.children[0]
+        self.assertTrue(child.negated)
+        self.assertEqual(child.variables[0].selector, "Content-Length")
+
+    def test_escaped_quote_inside_quoted_string(self):
+        self.assertEqual(self.by_id["950100"].first_action("msg"), 'Leak with "escaped quote" in msg')
+        self.assertEqual(self.by_id["942200"].argument, "(?i)ab[\"']c")
+
+    def test_default_paranoia_level(self):
+        self.assertEqual(self.by_id["920290"].paranoia_level, 1)
+
+
+class MappingTests(unittest.TestCase):
+    def test_map_targets(self):
+        targets, dropped, notes = owasp.map_targets(owasp.parse_variables(
+            "REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/*|TX:1|&ARGS"))
+        self.assertEqual(targets, ["COOKIES", "ARGS", "BODY"])
+        self.assertEqual(dropped, ["TX:1", "&ARGS"])
+        self.assertTrue(any("exclusion !REQUEST_COOKIES:/__utm/" in n for n in notes))
+        self.assertTrue(any("XML:/* widened to BODY" in n for n in notes))
+
+    def test_selector_targets(self):
+        targets, _, _ = owasp.map_targets(owasp.parse_variables("REQUEST_HEADERS:User-Agent|REQUEST_COOKIES:sid|ARGS:q"))
+        self.assertEqual(targets, ["HEADERS:User-Agent", "COOKIES:sid", "URL_PARAM:q"])
+
+    def test_host_header_maps_to_host_target(self):
+        targets, _, _ = owasp.map_targets(owasp.parse_variables("REQUEST_HEADERS:Host"))
+        self.assertEqual(targets, ["HOST"])
+
+    def test_regex_selector_widens(self):
+        targets, _, notes = owasp.map_targets(owasp.parse_variables("REQUEST_HEADERS:/^X-/"))
+        self.assertEqual(targets, ["HEADERS"])
+        self.assertTrue(any("widened" in n for n in notes))
+
+    def test_transformations(self):
+        chain, notes, bad = owasp.map_transformations(["none", "urlDecodeUni", "removeWhitespace", "cmdLine", "lowercase"])
+        self.assertIsNone(bad)
+        self.assertEqual(chain, ["urlDecodeUni", "compressWhitespace", "lowercase"])
+        self.assertEqual(len(notes), 2)
+
+    def test_none_resets_chain(self):
+        chain, _, _ = owasp.map_transformations(["lowercase", "none", "removeNulls"])
+        self.assertEqual(chain, ["removeNulls"])
+
+    def test_semantic_transformation_rejected(self):
+        _, _, bad = owasp.map_transformations(["base64Decode"])
+        self.assertEqual(bad, "base64Decode")
+
+    def test_phrases_to_pattern_is_sorted_and_escaped(self):
+        pattern = owasp.phrases_to_pattern(["bin/cat", "$HOME", "a.b", "bin/cat"])
+        self.assertEqual(pattern, r"(?i)(?:\$HOME|a\.b|bin/cat)")
+
+    def test_relax_anchors_only_for_collection_targets(self):
+        relaxed, note = owasp.relax_anchors(r"(?i)^https?://x$", ["ARGS", "BODY"])
+        self.assertEqual(relaxed, r'(?i)(?:^|[&="]|:\s*)https?://x(?:$|[&;"])')
+        self.assertIn("^ and $", note)
+        same, note = owasp.relax_anchors(r"^https?://x$", ["PATH", "HEADERS:Host"])
+        self.assertEqual(same, r"^https?://x$")
+        self.assertIsNone(note)
+        escaped, note = owasp.relax_anchors(r"price\$", ["ARGS"])
+        self.assertEqual(escaped, r"price\$")
+        self.assertIsNone(note)
+
+
+class TranslationTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        with open(os.path.join(self.tmp, "sample.conf"), "w") as fh:
+            fh.write(SAMPLE_CONF)
+        with open(os.path.join(self.tmp, "scanners.data"), "w") as fh:
+            fh.write("# comment\nnikto\nsqlmap\n\nNessus\n")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp)
+
+    def translate(self, tuning=None):
+        return owasp.translate_directory(self.tmp, "python", REPO_ROOT, tuning)
+
+    def test_translation_and_skips(self):
+        translated, skipped, totals = self.translate()
+        self.assertEqual(totals["sample.conf"], 13)
+        ported = {t.rule["id"]: t for t in translated}
+        self.assertEqual(sorted(ported), ["crs-913100", "crs-920350", "crs-931100", "crs-942100", "crs-942200", "crs-950100"])
+
+        sqli = ported["crs-942100"].rule
+        self.assertEqual(sqli["targets"], ["COOKIES", "ARGS", "BODY"])
+        self.assertEqual(sqli["transformations"], ["urlDecodeUni", "removeNulls"])
+        self.assertEqual(sqli["action"], "log")
+        self.assertEqual(sqli["score"], 5)
+        self.assertEqual(sqli["phase"], 2)
+        self.assertEqual(sqli["description"], "OWASP CRS 942100 PL1: SQL Injection Attack, with a comma")
+        self.assertEqual(list(sqli), ["id", "phase", "pattern", "targets", "severity", "action", "score", "description", "transformations"])
+
+        scanner = ported["crs-913100"].rule
+        self.assertEqual(scanner["pattern"], "(?i)(?:Nessus|nikto|sqlmap)")
+        self.assertEqual(scanner["targets"], ["HEADERS:User-Agent"])
+        self.assertEqual(scanner["transformations"], [])
+
+        rfi = ported["crs-931100"]
+        self.assertEqual(rfi.paranoia_level, 2)
+        self.assertTrue(rfi.rule["pattern"].startswith('(?:^|[&="]|:\\s*)https?://'))
+        self.assertTrue(rfi.rule["pattern"].endswith('(?:$|[&;"])'))
+        self.assertTrue(rfi.rule["transformations"], ["urlDecodeUni"])
+
+        self.assertEqual(ported["crs-920350"].rule["targets"], ["HOST"])
+        self.assertEqual(ported["crs-920350"].rule["pattern"], r"^[\d.:]+$")  # single value: anchors kept
+
+        leak = ported["crs-950100"].rule
+        self.assertEqual(leak["phase"], 4)
+        self.assertEqual(leak["pattern"], "(?i)(?:password|root)")
+        self.assertEqual(leak["score"], 4)
+
+        quote = ported["crs-942200"]
+        self.assertEqual(quote.rule["transformations"], ["urlDecodeUni", "lowercase", "compressWhitespace"])
+        self.assertEqual(quote.rule["score"], 2)
+        self.assertTrue(any("t:cmdLine dropped" in n for n in quote.notes))
+        self.assertTrue(any("t:removeWhitespace approximated" in n for n in quote.notes))
+
+        reasons = {s.id: s.category for s in skipped}
+        self.assertEqual(reasons, {
+            "942011": "control/flow rule",
+            "920290": "presence check",
+            "920170": "chained rule",
+            "942101": "non-regex operator",
+            "934100": "unsupported transformation",
+            "920420": "macro expansion",
+            "942999": "no mappable target",
+        })
+
+    def test_tuning(self):
+        path = os.path.join(self.tmp, "tuning.txt")
+        with open(path, "w") as fh:
+            fh.write("942100 remove-target BODY,COOKIES  # raw body\n913100 remove  # noisy\n931100\n")
+        tuning = owasp.read_tuning(path, "920350")
+        translated, skipped, _ = self.translate(tuning)
+        ported = {t.rule["id"]: t for t in translated}
+        self.assertEqual(sorted(ported), ["crs-942100", "crs-942200", "crs-950100"])
+        self.assertEqual(ported["crs-942100"].rule["targets"], ["ARGS"])
+        self.assertTrue(any("target BODY removed by tuning: raw body" in n for n in ported["crs-942100"].notes))
+        by_id = {s.id: s for s in skipped}
+        self.assertEqual(by_id["913100"].category, "removed by tuning")
+        self.assertEqual(by_id["913100"].detail, "noisy")
+        self.assertEqual(by_id["920350"].detail, "listed in --exclude")
+        self.assertEqual(by_id["931100"].category, "removed by tuning")
+
+    def test_tuning_syntax_error(self):
+        path = os.path.join(self.tmp, "tuning.txt")
+        with open(path, "w") as fh:
+            fh.write("942100 frobnicate BODY\n")
+        with self.assertRaises(SystemExit):
+            owasp.read_tuning(path, None)
+
+    def test_block_severity(self):
+        translated, _, _ = self.translate()
+        owasp.apply_block_severity(translated, "ERROR")
+        actions = {t.rule["id"]: t.rule["action"] for t in translated}
+        self.assertEqual(actions["crs-942100"], "block")  # CRITICAL
+        self.assertEqual(actions["crs-950100"], "block")  # ERROR
+        self.assertEqual(actions["crs-920350"], "log")    # WARNING
+        self.assertEqual(actions["crs-942200"], "log")    # NOTICE
+
+    def test_python_validator_rejects_pcre_only_syntax(self):
+        failures = owasp.python_heuristic_failures([
+            ("lookahead", r"a(?=b)"), ("backref", r"(a)\1"), ("escaped-qmark-plus", r"x\?+$"), ("plain", r"a+b*")])
+        self.assertEqual(sorted(failures), ["backref", "lookahead"])
+
+    @unittest.skipUnless(shutil.which("go"), "go toolchain not installed")
+    def test_go_validator_rejects_what_re2_rejects(self):
+        failures = owasp.re2_validate([("ok", r"(?i)a|b"), ("look", r"a(?=b)"), ("big", r"a{1001}")], "go", REPO_ROOT)
+        self.assertEqual(sorted(failures), ["big", "look"])
+
+    def test_report(self):
+        translated, skipped, totals = self.translate()
+        report = os.path.join(self.tmp, "COVERAGE.md")
+        owasp.write_report(report, "v0-test", translated, skipped, totals, {os.path.join(self.tmp, "crs-pl1.json"): 4})
+        text = open(report).read()
+        self.assertIn("# OWASP CRS v0-test translation coverage", text)
+        self.assertIn("- CRS rules with an id: 13", text)
+        self.assertIn("`crs-pl1.json`: 4 rules", text)
+        self.assertIn("| chained rule | 1 |", text)
+        self.assertIn("| 920170 | sample.conf | chained rule: caddy-waf has no rule chaining |", text)
+        self.assertIn("| crs-942200 | sample.conf |", text)
+
+    def test_cli_writes_bundles_and_report(self):
+        out = os.path.join(self.tmp, "out", "crs-pl1.json")
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = owasp.main(["--source", self.tmp, "--output", out, "--paranoia-level", "2", "--re2check", "python"])
+        self.assertEqual(rc, 0)
+        rules = json.load(open(out))
+        self.assertEqual([r["id"] for r in rules], ["crs-913100", "crs-920350", "crs-931100", "crs-942100", "crs-942200"])
+        response = json.load(open(os.path.join(self.tmp, "out", "crs-pl1-response.json")))
+        self.assertEqual([r["id"] for r in response], ["crs-950100"])
+        self.assertTrue(os.path.exists(os.path.join(self.tmp, "out", "COVERAGE.md")))
+
+    def test_cli_output_dir_splits_by_paranoia_level(self):
+        out_dir = os.path.join(self.tmp, "bundles")
+        with contextlib.redirect_stdout(io.StringIO()):
+            owasp.main(["--source", self.tmp, "--output-dir", out_dir, "--re2check", "python"])
+        pl1 = json.load(open(os.path.join(out_dir, "crs-pl1.json")))
+        pl2 = json.load(open(os.path.join(out_dir, "crs-pl2.json")))
+        self.assertEqual([r["id"] for r in pl2], ["crs-931100"])
+        self.assertNotIn("crs-931100", [r["id"] for r in pl1])
+        self.assertTrue(os.path.exists(os.path.join(out_dir, "crs-pl1-response.json")))
+        self.assertFalse(os.path.exists(os.path.join(out_dir, "crs-pl2-response.json")))
+        self.assertEqual(json.load(open(os.path.join(out_dir, "crs-pl3.json"))), [])
+
+
+class ScriptInvocationTest(unittest.TestCase):
+    def test_help_runs(self):
+        proc = subprocess.run([sys.executable, os.path.join(REPO_ROOT, "get_owasp_rules.py"), "--help"],
+                              capture_output=True, text=True, check=False)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("--paranoia-level", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/re2check/main.go
+++ b/tools/re2check/main.go
@@ -1,0 +1,51 @@
+// Command re2check reports which regular expressions Go's RE2 engine rejects.
+//
+// It exists so get_owasp_rules.py can validate translated OWASP CRS patterns
+// against the same regexp package caddy-waf compiles rules with. Python's re
+// module accepts backreferences, lookaround and other PCRE features that RE2
+// does not, so a Python-side check would let rules through that then fail to
+// load (see rules/README.md).
+//
+// Input:  a JSON array of {"id": "...", "pattern": "..."} objects on stdin.
+// Output: a JSON object on stdout mapping each rejected id to the compile
+// error. Patterns that compile are omitted, so an empty object means every
+// pattern is loadable.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+)
+
+type entry struct {
+	ID      string `json:"id"`
+	Pattern string `json:"pattern"`
+}
+
+func main() {
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "re2check: read stdin:", err)
+		os.Exit(2)
+	}
+	var entries []entry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		fmt.Fprintln(os.Stderr, "re2check: parse input:", err)
+		os.Exit(2)
+	}
+	failures := map[string]string{}
+	for _, e := range entries {
+		if _, err := regexp.Compile(e.Pattern); err != nil {
+			failures[e.ID] = err.Error()
+		}
+	}
+	out, err := json.Marshal(failures)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "re2check: encode output:", err)
+		os.Exit(2)
+	}
+	fmt.Println(string(out))
+}


### PR DESCRIPTION
Layer 1 of 3 of the CRS-informed rules work that #194 set up ("CRS-informed, not CRS parity"). Layers 2 and 3 (the generated PL1 bundle, then PL2–4) are stacked on this one and will be linked below. Reviewed twice by Copilot on my fork first (seanthegeek/caddy-waf#10); its findings are folded in.


## What

`get_owasp_rules.py` was a regex scrape of `SecRule` lines: it validated patterns with Python's `re` (which accepts lookaround and backreferences RE2 rejects), ignored `chain`, ignored `t:` chains, could not read `@pmFromFile` keyword lists, and mapped variables by substring search. This rewrites it as a real SecLang → caddy-waf translator:

- **Parser**: line continuations, chained rules (grouped, then skipped as a unit), quote-aware action splitting (`msg:'a, b'`), `\"` escapes, `SecAction`/`SecMarker` ignored.
- **Ported**: `@rx` as-is; `@pm`/`@pmFromFile` as a case-insensitive alternation, **sorted alphabetically so Go's regexp factors shared prefixes** (measured 10–20× faster to match than a length-sorted list).
- **Variables → targets**: `ARGS` → `ARGS` + `BODY` (ModSecurity's ARGS covers body params), `REQUEST_HEADERS:Host` → `HOST` (Go moves Host out of `r.Header`), `XML` → `BODY`, selectors → `HEADERS:x`/`COOKIES:x`/`URL_PARAM:x`, exclusions and counts dropped with a note.
- **`t:` → `transformations`**: engine names pass through; `removeWhitespace`/`removeComments` approximated; `cmdLine`/`normalizePath`/`jsDecode`/… dropped with a note (raw value is still matched); `base64Decode`/`length`/`sha1` make the rule unportable.
- **Anchor relaxation**: a leading `^`/trailing `$` on a collection target (`ARGS`, `BODY`, `HEADERS`, `COOKIES`) becomes a member boundary, because ModSecurity matches each value on its own and caddy-waf matches the raw query string / joined header list. Without this, e.g. CRS 931100 (`^https?://<ip>`) could only ever match the first query parameter.
- **Skips, all reported**: chained, non-regex operators, control-flow rules without severity, `^$` presence checks (this engine skips empty targets, per `dead_rules_test.go`), macro patterns, unmappable targets, RE2 rejections.
- **RE2 validation** via `tools/re2check` (`go run`, compiles with the same `regexp` package the WAF uses). `--re2check python` is a heuristic fallback.
- **Scoring/actions**: severity → score (5/4/3/2); every rule is `log`, so output is advisory until `log_scores_block` is set (consistent with #199). `--block-severity` opts into block rules.
- **Output**: per paranoia level (`--output-dir`) or cumulative (`--output --paranoia-level N`); request and response phases in separate files; `COVERAGE.md` report; `--tuning` file (`<id> remove`, `<id> remove-target BODY`).

## Tests

- `test_get_owasp_rules.py`: 26 unit tests on an inline SecLang sample (parser, mapping, anchors, tuning, report, CLI); added as a CI step.
- `go test ./...` and golangci-lint pass (`tools/re2check` is a `package main` inside the module).

## Docs

`docs/scripts.md` (options table, what is and is not ported), `rules/README.md`, CHANGELOG.

No rule files change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189Jgmgww6kay1vYqi6fFSx

