### PR TITLE
fix: remediate code-audit findings at 491552e2

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -33,8 +33,7 @@ paths:
 # - crypto: Used throughout Go ecosystem (always latest)
 # - opentelemetry: caddy → otel instrumentation
 #
-# All versions are current as of 2026-01-17:
-# - golang.org/x/crypto v0.47.0 (latest)
-# - github.com/go-sql-driver/mysql v1.9.3 (latest)
-# - github.com/slackhq/nebula v1.9.7 (pinned for smallstep compatibility)
-# - go.opentelemetry.io/auto/sdk v1.2.1 (latest)
+# go.mod / go.sum are the single source of truth for resolved dependency
+# versions; do not maintain a version list here (the previous hand-maintained
+# inventory drifted from go.mod). Run `go list -m all` or check go.mod for the
+# current versions.

--- a/.github/workflows/build-run-validate.yml
+++ b/.github/workflows/build-run-validate.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Build Caddy with caddy-waf
         run: |
           cd caddy-waf
-          go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+          go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.4.7
           xcaddy build --with github.com/fabriziosalmi/caddy-waf=./
 
       - name: Validate Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          GOOS=${GOOS} GOARCH=${GOARCH} go build -ldflags "-X 'github.com/fabriziosalmi/caddy-waf/middleware.ModuleVersion=${{ steps.extract_tag.outputs.TAG_NAME }}'" -o caddy-waf-${GOOS}-${GOARCH}
+          GOOS=${GOOS} GOARCH=${GOARCH} go build -ldflags "-X 'github.com/fabriziosalmi/caddy-waf.ModuleVersion=${{ steps.extract_tag.outputs.TAG_NAME }}'" -o caddy-waf-${GOOS}-${GOARCH}
           tar czf caddy-waf-${GOOS}-${GOARCH}.tar.gz caddy-waf-${GOOS}-${GOARCH}
 
       - name: Upload artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,12 +58,15 @@ jobs:
       run: |
         wget https://github.com/P3TERX/GeoLite.mmdb/releases/latest/download/GeoLite2-Country.mmdb
 
-    # Commented bits below were useful to allow the job to continue
-    # even if the tests fail, so we can publish the report separately
-    # For info about set-output, see https://stackoverflow.com/questions/57850553/github-actions-check-steps-status
-    - name: Run tests
+    # The suite runs under the race detector: the middleware is concurrent
+    # (atomic counters, a sync.Map of rule hits, a mutex-guarded metrics map,
+    # file-watcher goroutines) and ships metrics_concurrency_test.go, so the gate
+    # must exercise those under -race, not only functionally. -race requires cgo.
+    - name: Run tests (race detector)
+      env:
+        CGO_ENABLED: "1"
       run: |
-        go test -v -failfast ./... -tags=it
+        go test -race -v -failfast ./... -tags=it
 
     - name: Run rule-translator unit tests
       run: |

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -1,0 +1,41 @@
+name: Vulnerability Scan
+
+# Surfaces known advisories against the resolved dependency graph so new ones are
+# noticed (remediation for the dependency audit). govulncheck is reachability-aware:
+# advisories in code the WAF does not call are reported for visibility but do not
+# fail the job. It runs on pushes, pull requests, and a weekly schedule.
+#
+# It is informational (continue-on-error) on purpose: most open advisories here are
+# in Caddy's pinned transitive graph (see CHANGELOG "Not fixed, and why") and cannot
+# be cleared without a Caddy release, so blocking merges on them would be wrong.
+# Triage the summary: a *reachable* first-party advisory, or a stdlib advisory, means
+# bump the dependency or the Go toolchain.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.25"
+          check-latest: true
+
+      - name: Run govulncheck
+        continue-on-error: true
+        run: |
+          go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,10 @@ FROM --platform=$BUILDPLATFORM golang:1.27-alpine AS builder
 # the toolchain here has to be at least that. It was pinned to 1.24 and only
 # worked because GOTOOLCHAIN=auto silently downloaded a newer one mid-build.
 
-RUN apk add --no-cache git wget && \
-    go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+# xcaddy is pinned so the tool that assembles the artefact is fixed; bump it via
+# a tracked change rather than resolving @latest at build time.
+RUN apk add --no-cache git && \
+    go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.4.7
 
 WORKDIR /src
 
@@ -27,17 +29,21 @@ RUN go mod download
 
 COPY . .
 
-# GeoLite2 is optional at runtime, and this URL is a community mirror of
-# uncertain freshness (see docs/geoblocking.md). It is baked in so the country
-# and ASN examples work out of the box.
-RUN wget -q https://git.io/GeoLite2-Country.mmdb
+# GeoLite2 is NOT baked into the image: it was fetched from a community mirror of
+# uncertain freshness at build time, which made the artefact vary by build date
+# and embedded a data file of unknown provenance. Country/ASN filtering is
+# optional; mount an operator-supplied, versioned GeoLite2 database at runtime
+# instead (see docs/geoblocking.md and docs/docker.md).
 
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
     xcaddy build --with github.com/fabriziosalmi/caddy-waf=/src
 
 # --- Runtime ---
-FROM alpine:latest
+# Pin the runtime base so the shipped image's base layer is part of what the
+# commit describes; bump deliberately. For stronger reproducibility pin by digest
+# (FROM alpine:3.21@sha256:...).
+FROM alpine:3.21
 
 RUN apk add --no-cache ca-certificates && \
     addgroup -S caddy && adduser -S -G caddy caddy
@@ -45,7 +51,6 @@ RUN apk add --no-cache ca-certificates && \
 WORKDIR /app
 
 COPY --from=builder /src/caddy /usr/bin/caddy
-COPY --from=builder /src/GeoLite2-Country.mmdb /app/
 COPY --from=builder /src/rules.json /app/
 COPY --from=builder /src/ip_blacklist.txt /app/
 COPY --from=builder /src/dns_blacklist.txt /app/

--- a/caddywaf.go
+++ b/caddywaf.go
@@ -50,8 +50,37 @@ var (
 	_ caddy.Validator             = (*Middleware)(nil) // Assicurati che anche questa sia presente se hai un metodo Validate()
 )
 
-// Add or update the version constant as needed
-const wafVersion = "v0.4.14" // update this value to the new release version when tagging
+// ModuleVersion is injected at release build time via
+//
+//	-ldflags "-X 'github.com/fabriziosalmi/caddy-waf.ModuleVersion=<tag>'"
+//
+// (see .github/workflows/release.yml). It is empty for ordinary/dev builds. It
+// lives in this package so the -X path resolves to a real string variable
+// instead of being silently dropped by the linker.
+var ModuleVersion string
+
+// wafVersionDefault is the fallback version for non-release builds (releases
+// carry the git tag via ModuleVersion). Keep it a plain, single-line string
+// literal: the docs config (docs/.vitepress/config.mts) scrapes this constant
+// from the source, so a computed value would break the docs build.
+const wafVersionDefault = "v0.4.14"
+
+// wafVersion is the version the WAF reports in logs, metrics and build_info.
+// The release build injects ModuleVersion (from the git tag) which takes
+// precedence; otherwise wafVersionDefault is used.
+var wafVersion = func() string {
+	if ModuleVersion != "" {
+		return ModuleVersion
+	}
+	return wafVersionDefault
+}()
+
+// defaultAnomalyThreshold is the single source of truth for the cumulative
+// anomaly score at which a request is blocked when the operator does not set
+// anomaly_threshold. Both the Caddyfile adapter (config.go) and the JSON
+// Provision fallback (below) use it, so the two configuration sources cannot
+// silently diverge (they previously defaulted to 5 and 20 respectively).
+const defaultAnomalyThreshold = 5
 
 // ==================== Initialization and Setup ====================
 
@@ -159,7 +188,7 @@ func (m *Middleware) Provision(ctx caddy.Context) error {
 
 	// ADDED: Set default anomaly threshold if not provided or invalid
 	if m.AnomalyThreshold <= 0 {
-		m.AnomalyThreshold = 20 // Use a reasonable default value
+		m.AnomalyThreshold = defaultAnomalyThreshold // shared with the Caddyfile default so JSON and Caddyfile configs agree
 		m.logger.Info("Using default anomaly threshold", zap.Int("anomaly_threshold", m.AnomalyThreshold))
 	} else {
 		m.logger.Info("Using configured anomaly threshold", zap.Int("anomaly_threshold", m.AnomalyThreshold))
@@ -179,8 +208,11 @@ func (m *Middleware) Provision(ctx caddy.Context) error {
 	// Log the current version of the middleware
 	m.logVersion()
 
-	// Start file watchers for rule files and blacklist files
-	// Context cancellation could be added in the future to gracefully stop watchers.
+	// Start file watchers for rule files and blacklist files. Each watcher
+	// goroutine is bound to this module instance via m.watcherStop and torn down
+	// in Shutdown (m.watcherWG), so a Caddy reload does not leak the old module's
+	// watchers or their inotify handles.
+	m.watcherStop = make(chan struct{})
 	m.startFileWatcher(m.RuleFiles)
 	m.startFileWatcher([]string{m.IPBlacklistFile, m.DNSBlacklistFile, m.IPWhitelistFile})
 
@@ -258,7 +290,7 @@ func (m *Middleware) Provision(ctx caddy.Context) error {
 	m.configLoader = NewConfigLoader(m.logger)
 	m.blacklistLoader = NewBlacklistLoader(m.logger)
 	m.geoIPHandler = NewGeoIPHandler(m.logger)
-	m.requestValueExtractor = NewRequestValueExtractor(m.logger, m.RedactSensitiveData, m.MaxRequestBodySize)
+	m.requestValueExtractor = NewRequestValueExtractor(m.logger, m.redactEnabled(), m.MaxRequestBodySize)
 
 	// Configure GeoIP handler
 	m.geoIPHandler.WithGeoIPCache(m.geoIPCacheTTL)
@@ -315,6 +347,18 @@ func (m *Middleware) Provision(ctx caddy.Context) error {
 			zap.String("client_ip_header", m.ClientIPHeader))
 	}
 
+	// Build the optional allow-list for the internal dashboard/metrics/prometheus
+	// endpoints. When set, only these client IPs/CIDRs may reach those endpoints;
+	// unset means no built-in restriction (the operator must front them).
+	if len(m.MetricsAllowFrom) > 0 {
+		trie, expanded, err := buildIPTrie(m.MetricsAllowFrom, "metrics_allow_from")
+		if err != nil {
+			return err
+		}
+		m.metricsAllowTrie = trie
+		m.logger.Info("Metrics/dashboard endpoints restricted", zap.Int("allow_entries", len(expanded)))
+	}
+
 	// Load DNS blacklist
 	if m.DNSBlacklistFile != "" {
 		m.dnsBlacklist = make(map[string]struct{})
@@ -340,6 +384,15 @@ func (m *Middleware) Provision(ctx caddy.Context) error {
 func (m *Middleware) Shutdown(ctx context.Context) error {
 	m.logger.Info("Starting WAF middleware shutdown procedures")
 	m.isShuttingDown = true
+
+	// Stop the file watchers started in Provision and wait for them to exit, so a
+	// reload does not leave the old module's watcher goroutines (and their inotify
+	// handles) running against stale files.
+	if m.watcherStop != nil {
+		close(m.watcherStop)
+		m.watcherWG.Wait()
+		m.watcherStop = nil
+	}
 
 	// Stop the rate limiter cleanup
 	if m.rateLimiter != nil {
@@ -433,6 +486,46 @@ func (m *Middleware) logVersion() {
 	m.logger.Info("WAF middleware version", zap.String("version", wafVersion))
 }
 
+// redactEnabled resolves the RedactSensitiveData pointer: redaction is ON when
+// the operator did not set it (nil) or set it true, and only OFF when explicitly
+// disabled. Keeping the default in one place means the Caddyfile and JSON sources
+// cannot diverge (they both default ON).
+func (m *Middleware) redactEnabled() bool {
+	return m.RedactSensitiveData == nil || *m.RedactSensitiveData
+}
+
+// countLoadedRules returns the total number of rules currently loaded across all
+// phases. It backs the rules_loaded metric (JSON and Prometheus) so operators
+// can alert on rules_loaded == 0 -- an inert WAF, otherwise indistinguishable
+// from clean traffic in the other counters.
+func (m *Middleware) countLoadedRules() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	n := 0
+	for _, rs := range m.Rules {
+		n += len(rs)
+	}
+	return n
+}
+
+// internalEndpointAllowed reports whether the request may reach the built-in
+// dashboard/metrics/prometheus endpoints. When metrics_allow_from is unset
+// (metricsAllowTrie == nil) it returns true and the endpoints behave as before
+// (the operator must front them). When set, only clients whose resolved IP is in
+// the allow-list are served; others fall through to normal handling, hiding the
+// telemetry rather than exposing it.
+func (m *Middleware) internalEndpointAllowed(r *http.Request) bool {
+	if m.metricsAllowTrie == nil {
+		return true
+	}
+	ip := m.clientIP(r)
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return false
+	}
+	return m.metricsAllowTrie.Contains(addr)
+}
+
 // isRuleFile reports whether path is one of the configured rule files, so the
 // watcher can pick ReloadRules vs ReloadConfig by identity rather than by a
 // "rule" substring match (which would misroute a blacklist/whitelist file whose
@@ -463,8 +556,9 @@ func (m *Middleware) startFileWatcher(filePaths []string) {
 			continue
 		}
 
-		// Note: In future, a context may be used here for cancellation.
+		m.watcherWG.Add(1)
 		go func(file string) {
+			defer m.watcherWG.Done()
 			watcher, err := fsnotify.NewWatcher()
 			if err != nil {
 				m.logger.Error("Failed to start file watcher", zap.Error(err))
@@ -488,6 +582,9 @@ func (m *Middleware) startFileWatcher(filePaths []string) {
 
 			for {
 				select {
+				case <-m.watcherStop:
+					// Module is shutting down; the deferred watcher.Close() runs on return.
+					return
 				case event, ok := <-watcher.Events:
 					if !ok {
 						return
@@ -734,6 +831,7 @@ func (m *Middleware) handleMetricsRequest(w http.ResponseWriter, r *http.Request
 		"dns_blacklist_hits":            dnsBlacklistHits,
 		"rate_limiter_requests":         rateLimiterTotalRequests,
 		"rate_limiter_blocked_requests": rateLimiterBlockedRequests,
+		"rules_loaded":                  m.countLoadedRules(),
 		"version":                       wafVersion,
 	}
 	for k, v := range m.observabilitySnapshot() {

--- a/config.go
+++ b/config.go
@@ -128,6 +128,14 @@ func (cl *ConfigLoader) parseRateLimit(d *caddyfile.Dispenser, m *Middleware) er
 			rl.MatchAllPaths = matchAllPaths
 			cl.logger.Debug("Rate limit match_all_paths set", zap.Bool("match_all_paths", rl.MatchAllPaths))
 
+		case "max_entries":
+			maxEntries, err := cl.parsePositiveInteger(d, "max_entries")
+			if err != nil {
+				return err
+			}
+			rl.MaxEntries = maxEntries
+			cl.logger.Debug("Rate limit max_entries set", zap.Int("max_entries", rl.MaxEntries))
+
 		default:
 			return d.Errf("unrecognized rate_limit option: %s", option)
 		}
@@ -162,41 +170,44 @@ func (cl *ConfigLoader) UnmarshalCaddyfile(d *caddyfile.Dispenser, m *Middleware
 	// Set default values
 	m.LogSeverity = "info"
 	m.LogJSON = false
-	m.AnomalyThreshold = 5
+	m.AnomalyThreshold = defaultAnomalyThreshold // shared with the JSON Provision fallback so both sources agree
 	m.CountryBlacklist.Enabled = false
 	m.CountryWhitelist.Enabled = false
 	m.LogFilePath = "debug.json"
-	m.RedactSensitiveData = false
+	// RedactSensitiveData is left nil here so it defaults ON via redactEnabled(),
+	// consistently for both the Caddyfile and JSON sources; `redact_sensitive_data off` disables it.
 	m.LogBuffer = 1000
 	m.BlockASNs.Enabled = false // Default to false
 
 	directiveHandlers := map[string]func(d *caddyfile.Dispenser, m *Middleware) error{
-		"metrics_endpoint":       cl.parseMetricsEndpoint,
-		"dashboard":              cl.parseDashboard,
-		"prometheus_endpoint":    cl.parsePrometheusEndpoint,
-		"log_path":               cl.parseLogPath,
-		"rate_limit":             cl.parseRateLimit,
-		"block_countries":        cl.parseCountryBlockDirective(true),  // Use directive-specific helper
-		"whitelist_countries":    cl.parseCountryBlockDirective(false), // Use directive-specific helper
-		"block_asns":             cl.parseBlockASNsDirective,           // Add ASN block directive
-		"geoip_fail_open":        cl.parseGeoIPFailOpen,
-		"log_severity":           cl.parseLogSeverity,
-		"log_json":               cl.parseLogJSON,
-		"rule_file":              cl.parseRuleFile,
-		"ip_blacklist_file":      cl.parseBlacklistFileDirective(true), // Use directive-specific helper
-		"whitelist_ip":           cl.parseWhitelistIP,
-		"whitelist_file":         cl.parseWhitelistFile,
-		"trusted_proxies":        cl.parseTrustedProxies,
-		"client_ip_header":       cl.parseClientIPHeader,
-		"dns_blacklist_file":     cl.parseBlacklistFileDirective(false), // Use directive-specific helper
-		"anomaly_threshold":      cl.parseAnomalyThreshold,
-		"custom_response":        cl.parseCustomResponse,
-		"redact_sensitive_data":  cl.parseRedactSensitiveData,
-		"log_scores_block":       cl.parseLogScoresBlock,
-		"tor":                    cl.parseTorBlock,
-		"log_buffer":             cl.parseLogBuffer,
-		"max_request_body_size":  cl.parseMaxRequestBodySize,
-		"max_response_body_size": cl.parseMaxResponseBodySize,
+		"metrics_endpoint":            cl.parseMetricsEndpoint,
+		"dashboard":                   cl.parseDashboard,
+		"prometheus_endpoint":         cl.parsePrometheusEndpoint,
+		"log_path":                    cl.parseLogPath,
+		"rate_limit":                  cl.parseRateLimit,
+		"block_countries":             cl.parseCountryBlockDirective(true),  // Use directive-specific helper
+		"whitelist_countries":         cl.parseCountryBlockDirective(false), // Use directive-specific helper
+		"block_asns":                  cl.parseBlockASNsDirective,           // Add ASN block directive
+		"geoip_fail_open":             cl.parseGeoIPFailOpen,
+		"log_severity":                cl.parseLogSeverity,
+		"log_json":                    cl.parseLogJSON,
+		"rule_file":                   cl.parseRuleFile,
+		"ip_blacklist_file":           cl.parseBlacklistFileDirective(true), // Use directive-specific helper
+		"whitelist_ip":                cl.parseWhitelistIP,
+		"whitelist_file":              cl.parseWhitelistFile,
+		"trusted_proxies":             cl.parseTrustedProxies,
+		"client_ip_header":            cl.parseClientIPHeader,
+		"dns_blacklist_file":          cl.parseBlacklistFileDirective(false), // Use directive-specific helper
+		"anomaly_threshold":           cl.parseAnomalyThreshold,
+		"custom_response":             cl.parseCustomResponse,
+		"redact_sensitive_data":       cl.parseRedactSensitiveData,
+		"log_scores_block":            cl.parseLogScoresBlock,
+		"tor":                         cl.parseTorBlock,
+		"log_buffer":                  cl.parseLogBuffer,
+		"max_request_body_size":       cl.parseMaxRequestBodySize,
+		"max_response_body_size":      cl.parseMaxResponseBodySize,
+		"block_oversize_request_body": cl.parseBlockOversizeRequestBody,
+		"metrics_allow_from":          cl.parseMetricsAllowFrom,
 	}
 
 	for d.Next() {
@@ -492,9 +503,58 @@ func (cl *ConfigLoader) parseLogScoresBlock(d *caddyfile.Dispenser, m *Middlewar
 	return nil
 }
 
+// parseRedactSensitiveData toggles redaction of sensitive values in logs. It is
+// on by default; this directive accepts an optional boolean so an operator can
+// disable it (`redact_sensitive_data off`) or set it explicitly, mirroring
+// geoip_fail_open. A bare directive enables it.
 func (cl *ConfigLoader) parseRedactSensitiveData(d *caddyfile.Dispenser, m *Middleware) error {
-	m.RedactSensitiveData = true
-	cl.logger.Debug("Redact sensitive data enabled", zap.String("file", d.File()), zap.Int("line", d.Line()))
+	value := true
+	if d.NextArg() {
+		switch strings.ToLower(d.Val()) {
+		case "true", "on", "yes", "1":
+			value = true
+		case "false", "off", "no", "0":
+			value = false
+		default:
+			return d.Errf("invalid redact_sensitive_data value '%s': expected true/false (also accepts on/off, yes/no, 1/0)", d.Val())
+		}
+	}
+	m.RedactSensitiveData = &value
+	cl.logger.Debug("Redact sensitive data set", zap.Bool("enabled", value), zap.String("file", d.File()), zap.Int("line", d.Line()))
+	return nil
+}
+
+// parseBlockOversizeRequestBody toggles fail-closed handling of request bodies
+// larger than max_request_body_size. Off by default (the oversize tail is
+// forwarded un-inspected, preserving streaming of large legitimate bodies); on,
+// such a request is blocked. Accepts an optional boolean; a bare directive enables it.
+func (cl *ConfigLoader) parseBlockOversizeRequestBody(d *caddyfile.Dispenser, m *Middleware) error {
+	value := true
+	if d.NextArg() {
+		switch strings.ToLower(d.Val()) {
+		case "true", "on", "yes", "1":
+			value = true
+		case "false", "off", "no", "0":
+			value = false
+		default:
+			return d.Errf("invalid block_oversize_request_body value '%s': expected true/false (also accepts on/off, yes/no, 1/0)", d.Val())
+		}
+	}
+	m.BlockOversizeRequestBody = value
+	cl.logger.Debug("Block oversize request body set", zap.Bool("enabled", value), zap.String("file", d.File()), zap.Int("line", d.Line()))
+	return nil
+}
+
+// parseMetricsAllowFrom restricts the dashboard/metrics/prometheus endpoints to
+// the given IPs/CIDRs (or the private_ranges token). With no allow-list the
+// endpoints carry no built-in restriction and the operator must front them.
+func (cl *ConfigLoader) parseMetricsAllowFrom(d *caddyfile.Dispenser, m *Middleware) error {
+	entries := d.RemainingArgs()
+	if len(entries) == 0 {
+		return d.Err("metrics_allow_from requires at least one IP, CIDR range, or the token private_ranges")
+	}
+	m.MetricsAllowFrom = append(m.MetricsAllowFrom, entries...)
+	cl.logger.Debug("Metrics allow-from configured", zap.Strings("entries", entries), zap.String("file", d.File()), zap.Int("line", d.Line()))
 	return nil
 }
 

--- a/crs_bundle_test.go
+++ b/crs_bundle_test.go
@@ -70,7 +70,7 @@ func TestCRSBundlesAreLoadable(t *testing.T) {
 				t.Fatalf("%s: rule %s is also defined in %s", path, r.ID, prev)
 			}
 			seen[r.ID] = path
-			require.Equalf(t, "log", r.Action, "%s: %s must be a log rule", path, r.ID)
+			require.Equalf(t, "log", string(r.Action), "%s: %s must be a log rule", path, r.ID)
 			require.NotNilf(t, r.Transformations, "%s: %s must set an explicit transformations chain", path, r.ID)
 			require.NoErrorf(t, validateRule(&r), "%s: %s", path, r.ID)
 			require.Containsf(t, []int{2, 3, 4, 5}, r.Score, "%s: %s score must derive from a CRS severity", path, r.ID)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,10 @@ services:
       - ./ip_blacklist.txt:/app/ip_blacklist.txt
       - ./dns_blacklist.txt:/app/dns_blacklist.txt
     restart: unless-stopped
-    environment:
-      - CADDY_ADMIN=0.0.0.0:2019
+    # Caddy's admin API (:2019) is unauthenticated and can reconfigure or stop the
+    # server. It is left at Caddy's default localhost:2019 bind so it is not
+    # reachable from other containers on this network. If you must expose it,
+    # bind it to a dedicated internal address and put auth/mTLS in front.
     networks:
       - caddy-waf-net
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -13,8 +13,8 @@ const wafVersion = (() => {
     fileURLToPath(new URL('../../caddywaf.go', import.meta.url)),
     'utf8',
   )
-  const m = src.match(/wafVersion\s*=\s*"(v[^"]+)"/)
-  if (!m) throw new Error('could not read wafVersion from caddywaf.go')
+  const m = src.match(/wafVersionDefault\s*=\s*"(v[^"]+)"/)
+  if (!m) throw new Error('could not read wafVersionDefault from caddywaf.go')
   return m[1]
 })()
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -37,7 +37,7 @@ If the configured `metrics_endpoint` matches the request path, the middleware se
 - It does not modify request bodies; it only inspects them. The body is read through `io.LimitReader` and re-attached with `io.MultiReader` so downstream handlers receive the full body.
 - It does not perform TLS termination, HTTP routing, or response generation beyond the metrics endpoint and block responses; those remain the responsibility of Caddy and downstream handlers.
 - It does not learn or self-tune; rules are static JSON files reloaded on change.
-- It does not emit Prometheus directly; it exposes JSON that an external exporter can convert (see [prometheus.md](prometheus.md)).
+- It exposes metrics on two surfaces: a JSON document (`metrics_endpoint`) and a native Prometheus text-exposition endpoint (`prometheus_endpoint`, including a request-duration histogram) — scrape the latter directly, no external exporter needed (see [prometheus.md](prometheus.md) and [metrics.md](metrics.md)).
 
 ## Next step
 

--- a/handler.go
+++ b/handler.go
@@ -76,6 +76,19 @@ func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next cadd
 	// Initialize WAF state for this request
 	state := m.initializeWAFState()
 
+	// Fail closed on an oversize request body when the operator opted in: only the
+	// inspection window was scanned, so forwarding the un-inspected tail would let
+	// a payload placed past the window evade body rules. Off by default so large
+	// legitimate bodies keep streaming.
+	if m.BlockOversizeRequestBody {
+		if overflow, _ := r.Context().Value(bodyOverflowKey{}).(bool); overflow {
+			m.blockRequest(w, r, state, http.StatusRequestEntityTooLarge, "oversize_request_body", "",
+				zap.Int64("max_request_body_size", m.MaxRequestBodySize))
+			m.logRequestCompletion(logID, state)
+			return nil
+		}
+	}
+
 	// Phase 1: Pre-request checks and blocking
 	if m.isPhaseBlocked(w, r, 1, state) {
 		return nil // Request blocked, short-circuit
@@ -99,19 +112,19 @@ func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next cadd
 	//
 	// It sits after Phase 1 and 2 on purpose: the IP blacklist, the rate limiter
 	// and the request rules still apply, so the endpoint can be protected.
-	if m.isPrometheusRequest(r) {
+	if m.isPrometheusRequest(r) && m.internalEndpointAllowed(r) {
 		m.incrementAllowedRequestsMetric()
 		m.logRequestCompletion(logID, state)
 		return m.handlePrometheusRequest(w, r)
 	}
 
-	if m.isDashboardRequest(r) {
+	if m.isDashboardRequest(r) && m.internalEndpointAllowed(r) {
 		m.incrementAllowedRequestsMetric()
 		m.logRequestCompletion(logID, state)
 		return m.serveDashboard(w, r)
 	}
 
-	if m.isMetricsRequest(r) {
+	if m.isMetricsRequest(r) && m.internalEndpointAllowed(r) {
 		m.incrementAllowedRequestsMetric()
 		m.logRequestCompletion(logID, state)
 		return m.handleMetricsRequest(w, r)
@@ -134,10 +147,25 @@ func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next cadd
 	if state.Blocked {
 		// Metrics and response handling if blocked after headers phase
 		m.incrementBlockedRequestsMetric()
-		// Write to w, not to the recorder: the recorder's buffer is discarded on
-		// the blocked path, so a custom body written into it would never reach
-		// the client.
-		m.writeCustomResponse(w, state.StatusCode)
+		// In inspect mode the recorder held the status, so a Phase 3/4 block can
+		// still set it here. forwardHeader guards against a double WriteHeader when
+		// the recorder already streamed (passthrough), in which case the status was
+		// committed upstream and cannot be changed. The recorder's buffered body is
+		// discarded on the blocked path, so the block body is written straight to w.
+		if custom, ok := m.CustomResponses[state.StatusCode]; ok {
+			for k, v := range custom.Headers {
+				w.Header().Set(k, v)
+			}
+			recorder.forwardHeader(custom.StatusCode)
+			if _, err := w.Write([]byte(custom.Body)); err != nil {
+				m.logger.Error("Failed to write custom response body", zap.Error(err))
+			}
+		} else {
+			recorder.forwardHeader(state.StatusCode)
+			if _, err := w.Write([]byte("Request blocked by WAF.")); err != nil {
+				m.logger.Error("Failed to write blocked response body", zap.Error(err))
+			}
+		}
 		return nil
 	}
 
@@ -150,6 +178,20 @@ func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next cadd
 	m.logRequestCompletion(logID, state)
 
 	return err // Return any error from the next handler
+}
+
+// dispatchRuleMatch applies a matched rule via processRuleMatch. In the response
+// phases (3/4) it passes the response recorder as the writer so a response-phase
+// block records against it; otherwise it uses the original writer. It returns
+// processRuleMatch's shouldContinue value. Extracted from handlePhase to keep
+// that function's control flow within reach.
+func (m *Middleware) dispatchRuleMatch(w http.ResponseWriter, r *http.Request, rule *Rule, target, value string, phase int, state *WAFState) bool {
+	if phase == 3 || phase == 4 {
+		if recorder, ok := w.(*responseRecorder); ok {
+			return m.processRuleMatch(recorder, r, rule, target, value, state)
+		}
+	}
+	return m.processRuleMatch(w, r, rule, target, value, state)
 }
 
 // isPhaseBlocked encapsulates the phase handling and blocking check logic.
@@ -254,10 +296,19 @@ func (m *Middleware) captureRequestBody(r *http.Request) *http.Request {
 	if limit <= 0 {
 		limit = 10 * 1024 * 1024 // 10MB, matching the extractor default
 	}
-	buf, err := bufferRequestBody(r, limit)
+	buf, overflow, err := bufferRequestBody(r, limit)
 	if err != nil {
 		m.logger.Warn("Failed to buffer request body; leaving it untouched", zap.Error(err))
 		return r
+	}
+	if overflow {
+		// The body is larger than the inspection window, so only its prefix is
+		// scanned. Always surface it; ServeHTTP blocks the request only when the
+		// operator set block_oversize_request_body.
+		m.logger.Warn("Request body exceeds inspection window; only the first bytes are inspected",
+			zap.Int64("max_request_body_size", limit),
+			zap.Bool("block_oversize_request_body", m.BlockOversizeRequestBody))
+		r = r.WithContext(context.WithValue(r.Context(), bodyOverflowKey{}, true))
 	}
 	return r.WithContext(context.WithValue(r.Context(), bodyBufferKey{}, buf))
 }
@@ -354,6 +405,9 @@ func (m *Middleware) copyResponse(w http.ResponseWriter, recorder *responseRecor
 	if logID == "unknown" {
 		m.logger.Error("Log ID not found in context during response copy")
 	}
+	// In inspect mode the recorder held the status until now so a Phase 3/4 block
+	// could still set it; forward the (unblocked) status before the body.
+	recorder.forwardHeader(recorder.StatusCode())
 	_, err := w.Write(recorder.body.Bytes())
 	if err != nil {
 		m.logger.Error("Failed to write recorded response body to client", zap.Error(err), zap.String("log_id", logID))
@@ -606,7 +660,12 @@ func (m *Middleware) handlePhase(w http.ResponseWriter, r *http.Request, phase i
 		// every rule on the hot path).
 
 		for _, target := range rule.Targets {
-			m.logger.Debug("Extracting value for target", zap.String("target", target), zap.String("rule_id", rule.ID))
+			// Use Check/Write so the zap.Field slice is not built on the hot path
+			// (once per rule*target) when debug logging is disabled, which is the
+			// default (info) level.
+			if ce := m.logger.Check(zapcore.DebugLevel, "Extracting value for target"); ce != nil {
+				ce.Write(zap.String("target", target), zap.String("rule_id", rule.ID))
+			}
 			value, err := extract(target)
 			if err != nil {
 				m.logger.Debug("Failed to extract value for target, skipping rule for this target",
@@ -642,17 +701,9 @@ func (m *Middleware) handlePhase(w http.ResponseWriter, r *http.Request, phase i
 					zap.String("value", redactedValue),
 				)
 
-				// FIXED: Correctly interpret processRuleMatch return value
-				var shouldContinue bool
-				if phase == 3 || phase == 4 {
-					if recorder, ok := w.(*responseRecorder); ok {
-						shouldContinue = m.processRuleMatch(recorder, r, &rule, target, value, state)
-					} else {
-						shouldContinue = m.processRuleMatch(w, r, &rule, target, value, state)
-					}
-				} else {
-					shouldContinue = m.processRuleMatch(w, r, &rule, target, value, state)
-				}
+				// Dispatch the match. In the response phases (3/4) the recorder is
+				// the writer to record against; see dispatchRuleMatch.
+				shouldContinue := m.dispatchRuleMatch(w, r, &rule, target, value, phase, state)
 
 				// If processRuleMatch returned false or state is now blocked, stop processing
 				if !shouldContinue || state.Blocked || state.ResponseWritten {

--- a/logging.go
+++ b/logging.go
@@ -141,7 +141,7 @@ func (m *Middleware) prepareLogFields(r *http.Request, fields []zap.Field) []zap
 		requestPath = r.URL.Path
 		queryParams = r.URL.RawQuery
 	}
-	if m.RedactSensitiveData {
+	if m.redactEnabled() {
 		queryParams = m.redactQueryParams(queryParams)
 	}
 

--- a/logging_test.go
+++ b/logging_test.go
@@ -94,8 +94,9 @@ func TestRedactQueryParams(t *testing.T) {
 }
 
 func TestPrepareLogFields(t *testing.T) {
+	redact := true
 	m := &Middleware{
-		RedactSensitiveData: true,
+		RedactSensitiveData: &redact,
 		logger:              zaptest.NewLogger(t),
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2030,9 +2030,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/prometheus.go
+++ b/prometheus.go
@@ -118,6 +118,11 @@ func (m *Middleware) renderPrometheus() string {
 	// Build info.
 	fmt.Fprintf(&b, "# HELP caddywaf_build_info Build information.\n# TYPE caddywaf_build_info gauge\ncaddywaf_build_info{version=\"%s\"} 1\n", promLabel(wafVersion))
 
+	// Loaded-rule gauge: rules_loaded == 0 means the WAF is inert (no rules
+	// loaded), which is otherwise indistinguishable from clean traffic in the
+	// other counters. Alert on caddywaf_rules_loaded == 0.
+	fmt.Fprintf(&b, "# HELP caddywaf_rules_loaded Number of rules currently loaded across all phases.\n# TYPE caddywaf_rules_loaded gauge\ncaddywaf_rules_loaded %d\n", m.countLoadedRules())
+
 	return b.String()
 }
 

--- a/ratelimiter.go
+++ b/ratelimiter.go
@@ -22,7 +22,16 @@ type RateLimit struct {
 	Paths           []string         `json:"paths,omitempty"` // Optional paths to apply rate limit
 	PathRegexes     []*regexp.Regexp `json:"-"`               // Compiled regexes for the given paths
 	MatchAllPaths   bool             `json:"match_all_paths,omitempty"`
+	// MaxEntries caps the number of distinct (IP, path) keys tracked at once, so
+	// a flood of unique source IPs cannot grow the map without bound between
+	// cleanup passes. <= 0 uses defaultRateLimiterMaxEntries.
+	MaxEntries int `json:"max_entries,omitempty"`
 }
+
+// defaultRateLimiterMaxEntries bounds the rate-limiter key table when the
+// operator does not set max_entries, so memory stays bounded by default rather
+// than growing with attacker-controlled source-IP cardinality.
+const defaultRateLimiterMaxEntries = 1_000_000
 
 // RateLimiter struct
 type RateLimiter struct {
@@ -30,6 +39,8 @@ type RateLimiter struct {
 	requests        map[string]map[string]*requestCounter // Nested map for path-based rate limiting
 	config          RateLimit
 	stopCleanup     chan struct{} // Channel to signal cleanup goroutine to stop
+	entryCount      int           // Number of tracked (IP, path) keys; bounded by maxEntries
+	maxEntries      int           // Cap on entryCount (0 means the default is applied in NewRateLimiter)
 	totalRequests   int64         // Total requests received by this rate limiter
 	blockedRequests int64         // Total requests blocked by this rate limiter
 	muMetrics       sync.RWMutex  // Mutex to protect metrics access
@@ -60,9 +71,15 @@ func NewRateLimiter(config RateLimit) (*RateLimiter, error) {
 		}
 	}
 
+	maxEntries := config.MaxEntries
+	if maxEntries <= 0 {
+		maxEntries = defaultRateLimiterMaxEntries
+	}
+
 	return &RateLimiter{
 		requests:    make(map[string]map[string]*requestCounter),
 		config:      config,
+		maxEntries:  maxEntries,
 		stopCleanup: make(chan struct{}), // Initialize the stopCleanup channel
 	}, nil
 }
@@ -104,31 +121,38 @@ func (rl *RateLimiter) isRateLimited(ip, path string) bool {
 
 	rl.incrementTotalRequestsMetric() // Metric under lock to ensure consistency (or use atomic outside)
 
-	// Initialize the nested map if it doesn't exist
-	if _, exists := rl.requests[ip]; !exists {
-		rl.requests[ip] = make(map[string]*requestCounter)
-	}
-
-	// Get or create the counter for the specific key (path + ip)
-	counter, exists := rl.requests[ip][key]
-	if exists {
-		if now.Sub(counter.window) > rl.config.Window {
-			// Window expired, reset the counter
-			rl.requests[ip][key] = &requestCounter{count: 1, window: now}
+	// Existing (IP, path) key: update it in place (no new entry).
+	if inner, ok := rl.requests[ip]; ok {
+		if counter, exists := inner[key]; exists {
+			if now.Sub(counter.window) > rl.config.Window {
+				// Window expired, reset the counter (same key, entry count unchanged).
+				counter.count = 1
+				counter.window = now
+				return false
+			}
+			// Window not expired, increment the counter.
+			counter.count++
+			if counter.count > rl.config.Requests {
+				rl.incrementBlockedRequestsMetric() // Increment if the request is going to be blocked.
+				return true
+			}
 			return false
 		}
-
-		// Window not expired, increment the counter
-		counter.count++
-		if counter.count > rl.config.Requests {
-			rl.incrementBlockedRequestsMetric() // Increment if the request is going to be blocked.
-			return true
-		}
-		return false
 	}
 
-	// IP and path combination doesn't exist, add it
-	rl.requests[ip][key] = &requestCounter{count: 1, window: now}
+	// A new (IP, path) key. Bound the table so a flood of distinct sources cannot
+	// grow it without limit between cleanup passes: once at capacity, stop
+	// tracking new keys (they are not rate-limited by this instance, but memory
+	// stays bounded) rather than admitting unbounded growth.
+	if rl.entryCount >= rl.maxEntries {
+		return false
+	}
+	if _, ok := rl.requests[ip]; !ok {
+		rl.requests[ip] = make(map[string]*requestCounter)
+	}
+	newCounter := &requestCounter{count: 1, window: now}
+	rl.requests[ip][key] = newCounter
+	rl.entryCount++
 	return false
 }
 
@@ -143,6 +167,7 @@ func (rl *RateLimiter) cleanupExpiredEntries() {
 		for path, counter := range pathCounters {
 			if now.Sub(counter.window) > rl.config.Window {
 				delete(pathCounters, path)
+				rl.entryCount--
 			}
 		}
 		if len(pathCounters) == 0 {

--- a/request.go
+++ b/request.go
@@ -219,6 +219,11 @@ func (rve *RequestValueExtractor) logIfEmpty(value string, target string, messag
 // still needs.
 type bodyBufferKey struct{}
 
+// bodyOverflowKey carries a bool in the request context indicating the request
+// body exceeded the inspection window (only its prefix was inspected). ServeHTTP
+// reads it to fail closed when block_oversize_request_body is set.
+type bodyOverflowKey struct{}
+
 // bufferRequestBody reads up to limit bytes of the request body for inspection
 // and rebuilds r.Body so the full body still reaches downstream and the upstream
 // proxy. It returns the inspection window (at most limit bytes).
@@ -234,39 +239,42 @@ type bodyBufferKey struct{}
 // while r.ContentLength kept its original value, so the upstream saw
 // "ContentLength=N with Body length 0", broke the connection, and every POST
 // carrying a body failed with a 502.
-func bufferRequestBody(r *http.Request, limit int64) ([]byte, error) {
+func bufferRequestBody(r *http.Request, limit int64) (bodyBytes []byte, overflow bool, err error) {
 	// Read the inspection window plus one byte, to learn whether the body
 	// exceeded the window without discarding the overflow.
 	buf, err := io.ReadAll(io.LimitReader(r.Body, limit+1))
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if int64(len(buf)) <= limit {
-		bodyBytes := buf
 		_ = r.Body.Close()
-		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		r.Body = io.NopCloser(bytes.NewReader(buf))
 		r.GetBody = func() (io.ReadCloser, error) {
-			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+			return io.NopCloser(bytes.NewReader(buf)), nil
 		}
-		return bodyBytes, nil
+		return buf, false, nil
 	}
-	// Body exceeds the inspection window: forward prefix + remainder, inspect the
-	// prefix only. The original body keeps streaming after the buffered bytes,
-	// and its Closer is preserved.
-	prefix := buf[:limit]
+	// Body exceeds the inspection window: forward the full body (buffered prefix +
+	// un-read remainder) but inspect only the window, and report the overflow so
+	// the caller can fail closed if the operator set block_oversize_request_body.
+	// The original body keeps streaming after the buffered bytes, and its Closer
+	// is preserved.
+	inspected := buf[:limit]
 	original := r.Body
 	r.Body = struct {
 		io.Reader
 		io.Closer
 	}{io.MultiReader(bytes.NewReader(buf), original), original}
-	return prefix, nil
+	return inspected, true, nil
 }
 
 // readAndRestoreBody buffers the body against the extractor's maxBodySize. It is
 // the fallback for extraction paths that were not pre-buffered by ServeHTTP
-// (e.g. a direct unit test).
+// (e.g. a direct unit test). The overflow flag is not surfaced on this path;
+// ServeHTTP's captureRequestBody handles the fail-closed policy.
 func (rve *RequestValueExtractor) readAndRestoreBody(r *http.Request) ([]byte, error) {
-	return bufferRequestBody(r, rve.maxBodySize)
+	buf, _, err := bufferRequestBody(r, rve.maxBodySize)
+	return buf, err
 }
 
 func (rve *RequestValueExtractor) extractBody(r *http.Request, target string) (string, error) {
@@ -448,14 +456,37 @@ func (rve *RequestValueExtractor) extractValueForJSONPath(r *http.Request, jsonP
 
 // Helper function to redact value if target is sensitive
 func (rve *RequestValueExtractor) RedactValueIfSensitive(target string, value string) string {
-	if rve.redactSensitiveData {
-		for _, sensitive := range sensitiveTargets {
-			if strings.Contains(strings.ToLower(target), sensitive) {
-				return "REDACTED"
-			}
+	if !rve.redactSensitiveData {
+		return value
+	}
+	lowerTarget := strings.ToLower(target)
+	for _, sensitive := range sensitiveTargets {
+		if strings.Contains(lowerTarget, sensitive) {
+			return "REDACTED"
 		}
 	}
+	// The target name alone misses secrets that ride inside a generic target (a
+	// token in ARGS, a password in BODY, an Authorization header inside the full
+	// HEADERS blob), so also redact when the value itself carries a sensitive key.
+	if valueLooksSensitive(value) {
+		return "REDACTED"
+	}
 	return value
+}
+
+// valueLooksSensitive reports whether value carries a secret regardless of the
+// target it came from: one of the sensitive key names immediately followed by an
+// assignment/separator (e.g. "password=", "token:", or the JSON form
+// "\"apikey\":"). It errs toward redacting the whole value once such a marker is
+// present rather than leaking part of it.
+func valueLooksSensitive(value string) bool {
+	lower := strings.ToLower(value)
+	for _, key := range sensitiveTargets {
+		if strings.Contains(lower, key+"=") || strings.Contains(lower, key+":") {
+			return true
+		}
+	}
+	return false
 }
 
 // Helper function to extract all cookies

--- a/response.go
+++ b/response.go
@@ -74,6 +74,7 @@ type responseRecorder struct {
 	limit       int64 // Maximum number of bytes retained in body for inspection.
 	passthrough bool  // True once writes go straight to the underlying writer.
 	partial     bool  // True if bytes reached the client before inspection completed.
+	headerSent  bool  // True once the status line has actually been forwarded to the client.
 }
 
 // NewResponseRecorder creates a new responseRecorder that buffers up to
@@ -101,10 +102,29 @@ func NewResponseRecorderWithLimit(w http.ResponseWriter, limit int64, inspect bo
 	}
 }
 
-// WriteHeader captures the response status code.
+// WriteHeader captures the response status code. In pass-through mode (no
+// response-phase inspection) it forwards the status to the client immediately.
+// In inspect mode it only records the status: the status line is held until the
+// WAF finishes Phase 3/4 evaluation, so a response-phase block can still set the
+// status. release() / copyResponse forwards it once inspection is done. Before
+// this, the upstream status was committed here immediately and a Phase 3/4 block
+// surfaced with the upstream's status (typically 200) instead of the block code.
 func (r *responseRecorder) WriteHeader(statusCode int) {
 	r.statusCode = statusCode
-	r.ResponseWriter.WriteHeader(statusCode)
+	if r.passthrough {
+		r.forwardHeader(statusCode)
+	}
+}
+
+// forwardHeader writes the status line to the underlying writer exactly once.
+// It is idempotent, so both the inspect path (copyResponse / block handling) and
+// the pass-through path can call it without risking a superfluous WriteHeader.
+func (r *responseRecorder) forwardHeader(code int) {
+	if r.headerSent {
+		return
+	}
+	r.headerSent = true
+	r.ResponseWriter.WriteHeader(code)
 }
 
 // Header returns the response headers.
@@ -179,6 +199,9 @@ func (r *responseRecorder) Flush() {
 func (r *responseRecorder) release() error {
 	r.partial = true
 	r.passthrough = true
+	// Send the held status before streaming: once bytes are on the wire the
+	// status can no longer change (Partial() reflects this).
+	r.forwardHeader(r.StatusCode())
 	if r.body.Len() == 0 {
 		return nil
 	}

--- a/rule_action_test.go
+++ b/rule_action_test.go
@@ -52,7 +52,7 @@ func TestRuleActionUnmarshalsFromJSON(t *testing.T) {
 	for _, phaseRules := range m.Rules {
 		for _, r := range phaseRules {
 			seen++
-			assert.Equalf(t, expected[r.ID], r.Action, "rule %q: Action must equal the file's \"action\" value", r.ID)
+			assert.Equalf(t, expected[r.ID], string(r.Action), "rule %q: Action must equal the file's \"action\" value", r.ID)
 		}
 	}
 	assert.Equal(t, len(expected), seen, "every rule in rules.json must load")
@@ -75,7 +75,7 @@ func TestRuleModeKeyStillAccepted(t *testing.T) {
 	}
 	got := map[string]string{}
 	for _, r := range rules {
-		got[r.ID] = r.Action
+		got[r.ID] = string(r.Action) // Action is now the named type RuleAction
 	}
 	assert.Equal(t, "block", got["legacy"], `"mode" must still populate Action`)
 	assert.Equal(t, "log", got["canonical"])

--- a/rules.go
+++ b/rules.go
@@ -68,7 +68,7 @@ func (m *Middleware) processRuleMatch(w http.ResponseWriter, r *http.Request, ru
 	// Debug the actual action field value to verify what's being used
 	m.logger.Debug("Rule action/mode check",
 		zap.String("rule_id", rule.ID),
-		zap.String("action_field", rule.Action),
+		zap.String("action_field", string(rule.Action)),
 		zap.Int("score", rule.Score),
 		zap.Int("threshold", m.AnomalyThreshold),
 		zap.Int("total_score", state.TotalScore))
@@ -116,7 +116,7 @@ func (m *Middleware) processRuleMatch(w http.ResponseWriter, r *http.Request, ru
 		m.logRequest(zapcore.DebugLevel, "Rule action: No Block", r,
 			zap.String("log_id", logID),
 			zap.String("rule_id", rule.ID),
-			zap.String("action", rule.Action),
+			zap.String("action", string(rule.Action)),
 			zap.Int("total_score", state.TotalScore),
 			zap.Int("anomaly_threshold", m.AnomalyThreshold),
 		)
@@ -195,7 +195,7 @@ func (m *Middleware) loadRules(paths []string) error {
 		if err != nil {
 			m.logger.Error("Failed to load rule file", zap.String("file", path), zap.Error(err))
 			invalidFiles = append(invalidFiles, path)
-			continue // Skip to the next file if loading fails
+			continue // record the failure; a partial initial load is rejected below (fail closed)
 		}
 
 		if len(fileInvalidRules) > 0 {
@@ -233,6 +233,15 @@ func (m *Middleware) loadRules(paths []string) error {
 	for _, rs := range m.Rules {
 		prevRuleCount += len(rs)
 	}
+	// Initial load (no rules held yet) must fail closed if any configured rule
+	// file could not be loaded: coming up with a partial rule set is silently
+	// reduced protection that only shows as one Error line in the startup log.
+	// The reload case (prevRuleCount > 0) is handled by the fail-safe below, which
+	// keeps the previously-loaded set.
+	if len(invalidFiles) > 0 && prevRuleCount == 0 {
+		return fmt.Errorf("initial rule load failed: %d rule file(s) could not be loaded (%v); refusing to start with a partial rule set", len(invalidFiles), invalidFiles)
+	}
+
 	loadFailed := len(invalidFiles) > 0 || (totalRules == 0 && len(paths) > 0)
 	if loadFailed && prevRuleCount > 0 {
 		return fmt.Errorf("rule reload failed (%d invalid file(s), %d rules parsed); keeping %d previously loaded rules", len(invalidFiles), totalRules, prevRuleCount)

--- a/tor.go
+++ b/tor.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -137,12 +138,39 @@ func (t *TorConfig) readExistingBlacklist() ([]string, error) {
 	return strings.Split(string(data), "\n"), nil
 }
 
-// writeBlacklist writes the updated IP blacklist to the file.
+// writeBlacklist writes the updated IP blacklist to the file atomically: it
+// writes to a temp file in the same directory, fsyncs it, then renames it over
+// the target. Rename is atomic within a filesystem, so a crash can never leave a
+// half-written (truncated) blacklist that loads as valid-but-shorter -- a reader
+// ever sees only the old complete file or the new complete file.
 func (t *TorConfig) writeBlacklist(ips []string) error {
 	data := strings.Join(ips, "\n")
-	err := os.WriteFile(t.TORIPBlacklistFile, []byte(data), 0o600)
+	dir := filepath.Dir(t.TORIPBlacklistFile)
+
+	tmp, err := os.CreateTemp(dir, ".tor-blacklist-*.tmp")
 	if err != nil {
-		return fmt.Errorf("failed to write IP blacklist file %s: %w", t.TORIPBlacklistFile, err) // Improved error message with filename
+		return fmt.Errorf("failed to create temp file for IP blacklist in %s: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we return before the rename succeeds.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write([]byte(data)); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to write temp IP blacklist file %s: %w", tmpName, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to fsync temp IP blacklist file %s: %w", tmpName, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close temp IP blacklist file %s: %w", tmpName, err)
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		return fmt.Errorf("failed to set permissions on temp IP blacklist file %s: %w", tmpName, err)
+	}
+	if err := os.Rename(tmpName, t.TORIPBlacklistFile); err != nil {
+		return fmt.Errorf("failed to atomically replace IP blacklist file %s: %w", t.TORIPBlacklistFile, err)
 	}
 	t.logger.Debug("Blacklist file updated", zap.String("path", t.TORIPBlacklistFile), zap.Int("entry_count", len(ips))) // Debug log for file update
 	return nil

--- a/types.go
+++ b/types.go
@@ -70,16 +70,36 @@ type ASNRecord struct {
 	AutonomousSystemNumber       uint   `maxminddb:"autonomous_system_number"`
 }
 
+// RuleAction is the closed set of actions a rule may take. It is a named type
+// rather than a bare string so the domain concept is explicit and comparisons
+// go through the constants below; load-time validation (Rule validation in
+// rules.go) rejects any value other than the two constants.
+type RuleAction string
+
+const (
+	// RuleActionBlock blocks the request on the first match.
+	RuleActionBlock RuleAction = "block"
+	// RuleActionLog records the match (and contributes its score) without blocking.
+	RuleActionLog RuleAction = "log"
+)
+
+// Valid reports whether a is one of the recognised actions. An empty action is
+// treated as valid here (it defaults to score-only/log behaviour downstream);
+// Rule validation enforces the block/log set for non-empty values.
+func (a RuleAction) Valid() bool {
+	return a == "" || a == RuleActionBlock || a == RuleActionLog
+}
+
 // Rule struct
 type Rule struct {
-	ID          string   `json:"id"`
-	Phase       int      `json:"phase"`
-	Pattern     string   `json:"pattern"`
-	Targets     []string `json:"targets"`
-	Severity    string   `json:"severity"` // Used for logging only
-	Score       int      `json:"score"`
-	Action      string   `json:"action"` // "block" or "log"; "mode" is accepted as an alias, see UnmarshalJSON
-	Description string   `json:"description"`
+	ID          string     `json:"id"`
+	Phase       int        `json:"phase"`
+	Pattern     string     `json:"pattern"`
+	Targets     []string   `json:"targets"`
+	Severity    string     `json:"severity"` // Used for logging only
+	Score       int        `json:"score"`
+	Action      RuleAction `json:"action"` // block or log; "mode" is accepted as an alias, see UnmarshalJSON
+	Description string     `json:"description"`
 	// Transformations is an optional per-rule ModSecurity/CRS-style pipeline
 	// (e.g. ["urlDecodeUni","removeNulls","replaceComments"]) applied to the
 	// extracted value before matching. A pointer so JSON can distinguish an
@@ -108,9 +128,9 @@ func (r *Rule) UnmarshalJSON(data []byte) error {
 	}
 	switch {
 	case aux.Action != nil:
-		r.Action = *aux.Action
+		r.Action = RuleAction(*aux.Action)
 	case aux.Mode != nil:
-		r.Action = *aux.Mode
+		r.Action = RuleAction(*aux.Mode)
 	}
 	return nil
 }
@@ -208,13 +228,28 @@ type Middleware struct {
 	geoIPCacheTTL               time.Duration
 	geoIPLookupFallbackBehavior string
 
-	CustomResponses     map[int]CustomBlockResponse `json:"custom_responses,omitempty"`
-	LogFilePath         string
-	LogBuffer           int   `json:"log_buffer,omitempty"` // Add the LogBuffer field
-	RedactSensitiveData bool  `json:"redact_sensitive_data,omitempty"`
+	CustomResponses map[int]CustomBlockResponse `json:"custom_responses,omitempty"`
+	LogFilePath     string
+	LogBuffer       int `json:"log_buffer,omitempty"` // Add the LogBuffer field
+	// RedactSensitiveData controls redaction of sensitive values in logs. A
+	// pointer so an omitted value (nil) can default to ON for both the Caddyfile
+	// and JSON sources without the two diverging; resolve it via redactEnabled().
+	// Set false explicitly (`redact_sensitive_data off` / JSON false) to disable.
+	RedactSensitiveData *bool `json:"redact_sensitive_data,omitempty"`
 	MaxRequestBodySize  int64 `json:"max_request_body_size,omitempty"`
 	MaxResponseBodySize int64 `json:"max_response_body_size,omitempty"`
 	GeoIPFailOpen       bool  `json:"geoip_fail_open,omitempty"`
+	// BlockOversizeRequestBody, when true, blocks a request whose body exceeds
+	// MaxRequestBodySize instead of forwarding the un-inspected tail. Off by
+	// default so large legitimate bodies keep streaming; on, it closes the
+	// inspection-window evasion where a payload is placed past the window.
+	BlockOversizeRequestBody bool `json:"block_oversize_request_body,omitempty"`
+	// MetricsAllowFrom optionally restricts the dashboard/metrics/prometheus
+	// endpoints to a set of client IPs/CIDRs (or the private_ranges token). Empty
+	// means no built-in restriction (the operator must front them). Compiled into
+	// metricsAllowTrie at Provision.
+	MetricsAllowFrom []string     `json:"metrics_allow_from,omitempty"`
+	metricsAllowTrie *iptrie.Trie `json:"-"`
 
 	ruleHits        sync.Map `json:"-"`
 	MetricsEndpoint string   `json:"metrics_endpoint,omitempty"`
@@ -266,6 +301,12 @@ type Middleware struct {
 
 	logChan chan LogEntry // Buffered channel for log entries
 	logDone chan struct{} // Signal to stop the logging worker
+
+	// watcherStop is closed in Shutdown to stop the per-file fsnotify watcher
+	// goroutines started in Provision; watcherWG waits for them to exit, so a
+	// Caddy reload does not leak the old module's watchers or their inotify handles.
+	watcherStop chan struct{}
+	watcherWG   sync.WaitGroup
 
 	ruleCache *RuleCache // New field for RuleCache
 


### PR DESCRIPTION
Remediates the admitted findings from the code-metrics audit of this repo at commit `491552e2`. All changes verified with the project gate: `go build ./...`, `go vet ./...`, and `go test -race ./... -tags=it` (green).

## Resolved

**Security / correctness**
- **Redaction is value-aware** (`request.go`): secrets carried in generic targets (ARGS/BODY/HEADERS) are now redacted, not just those whose *target name* matches. `redact_sensitive_data` is now a `*bool` that **defaults ON** for both Caddyfile and JSON (opt out with `redact_sensitive_data off` / JSON `false`) — no source divergence.
- **Fail-closed initial rule load** (`rules.go`): if a configured rule file can't load at startup, the WAF refuses to start instead of coming up with a partial rule set. Reload keeps the existing fail-safe.
- **Oversize-body evasion** (`request.go`/`handler.go`): new `block_oversize_request_body` (off by default; always warns) blocks requests whose body exceeds the inspection window.
- **Phase 3/4 block status** (`response.go`/`handler.go`): the recorder holds the status in inspect mode so a response-phase block delivers its configured status instead of the upstream 200.
- **anomaly_threshold** now has a single default (`5`) shared by Caddyfile and JSON (was 5 vs 20).
- Optional **`metrics_allow_from`** guard for the dashboard/metrics/prometheus endpoints (default open).

**Reliability / concurrency / data integrity**
- File-watcher goroutines are bound to the module (`watcherStop` + `WaitGroup`) and torn down in `Shutdown` — no goroutine/inotify leak across reloads.
- Tor blacklist written **atomically** (temp + fsync + rename).
- Rate-limiter key table **bounded** (`rate_limit { max_entries }`, default 1,000,000) — caps memory under a source-IP flood.

**Observability / testing**
- `caddywaf_rules_loaded` gauge + JSON `rules_loaded` (alert on `== 0` for an inert WAF).
- CI runs the suite under **`-race`**.

**Build / supply chain / docs**
- Dockerfile: pin `xcaddy@v0.4.7` and `alpine:3.21`, drop the build-time GeoLite2 bake.
- `release.yml` `-X` now targets the real `ModuleVersion` symbol, so version injection actually works.
- `docker-compose` no longer binds the admin API to `0.0.0.0:2019`.
- `npm audit fix` clears **nanoid**; new `vulncheck.yml` (govulncheck) surfaces advisories.
- Fixed stale `.fossa.yml` inventory and the `introduction.md` "no native Prometheus" claim.

**Quality / domain model**
- `Rule.Action` is now the named type `RuleAction` (`block`/`log` constants).
- Extracted `dispatchRuleMatch` from `handlePhase` to lower its complexity.

## Intentionally not changed (with reason)
- **No-op crypto finding** — the code correctly uses no weak crypto; "resolving" it would mean *introducing* MD5/DES/`math/rand`.
- **Module registration** stays `new(Middleware)` — the Caddy package-registry scanner rejects `&Middleware{}` (documented in `caddywaf.go`). The god-struct concern is incremental architectural work.
- **Transitive Go advisories** are pinned by Caddy **v2.11.4 (latest)** and are **not reachable** from the WAF (per govulncheck). Clearing them requires bumping `x/crypto`, which raises the **Go floor to 1.26** and diverges from Caddy's tested graph — a deliberate maintainer call, not bundled here.
- **vite/esbuild** advisories need a VitePress major the project explicitly declined (CHANGELOG "Not fixed, and why").

## Behavior changes worth noting
- `redact_sensitive_data` and `block_oversize_request_body` defaults: redaction now **on** by default; oversize-block stays off.
- CI `test.yml` now requires `CGO_ENABLED=1` (for `-race`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
