### PR TITLE
docs(site): SEO metadata — canonical, JSON-LD, llms.txt, security.txt

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -37,6 +37,21 @@ export default defineConfig({
 
   sitemap: { hostname: site },
 
+  // Emit a per-page rel=canonical. VitePress ships none, and without it the
+  // custom domain, the github.io origin and any tracking-parameter variants
+  // read as separate URLs. relativePath is the page's source file; index.md
+  // maps to the site root, every other page to its cleanUrl path.
+  transformPageData(pageData) {
+    const path = pageData.relativePath === 'index.md'
+      ? ''
+      : pageData.relativePath.replace(/\.md$/, '')
+    pageData.frontmatter.head ??= []
+    pageData.frontmatter.head.push([
+      'link',
+      { rel: 'canonical', href: `${site}${path}` },
+    ])
+  },
+
   markdown: {
     // Shiki ships no Caddyfile grammar. nginx is the closest fit -- directive,
     // arguments, braces, '#' comments -- and the docs carry 13 Caddyfile
@@ -74,10 +89,41 @@ export default defineConfig({
     ['meta', { property: 'og:url', content: site }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
     ['meta', { name: 'twitter:image', content: `${site}og.png` }],
+    // Let Google Discover show large image previews rather than a thumbnail.
+    // GitHub Pages cannot send an X-Robots-Tag header, so this lives in <head>.
+    [
+      'meta',
+      {
+        name: 'robots',
+        content: 'index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1',
+      },
+    ],
+    // Structured data so search engines and AI crawlers can identify the
+    // project as a piece of software rather than inferring it from prose.
+    [
+      'script',
+      { type: 'application/ld+json' },
+      JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'SoftwareApplication',
+        name: 'caddy-waf',
+        description:
+          'Web Application Firewall middleware for Caddy — regex rule engine with anomaly scoring, IP/DNS/ASN/country blacklists, rate limiting, and a JSON metrics endpoint.',
+        url: site,
+        applicationCategory: 'SecurityApplication',
+        operatingSystem: 'Linux, macOS, Windows',
+        softwareVersion: wafVersion,
+        license: 'https://www.gnu.org/licenses/agpl-3.0.html',
+        author: { '@type': 'Person', name: 'Fabrizio Salmi' },
+        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+      }),
+    ],
   ],
 
   themeConfig: {
-    logo: '/logo.svg',
+    // Object form so the nav-bar logo carries a real alt text; the bare string
+    // form renders alt="" and reads as an unlabelled image to crawlers.
+    logo: { src: '/logo.svg', alt: 'caddy-waf logo' },
 
     // Client-side index. No external search service is contacted, which keeps
     // the published site free of third-party requests.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 ---
 layout: home
+title: caddy-waf — Web Application Firewall for Caddy
+titleTemplate: false
 
 hero:
   name: caddy-waf

--- a/docs/public/.well-known/security.txt
+++ b/docs/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: https://github.com/fabriziosalmi/caddy-waf/security/advisories/new
+Policy: https://github.com/fabriziosalmi/caddy-waf/security/policy
+Preferred-Languages: en
+Canonical: https://www.caddy-waf.com/.well-known/security.txt
+Expires: 2027-09-08T00:00:00Z

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,36 @@
+# caddy-waf
+
+> Web Application Firewall middleware for Caddy. It runs inside the Caddy process — no sidecar and no cloud service in the request path — and inspects requests and responses across four phases with a regex rule engine (Go RE2, linear-time matching), anomaly scoring, IP/DNS/ASN/country blacklists, rate limiting, GeoIP, a Tor exit-node list, and a JSON metrics endpoint. Registered as the Caddy module `http.handlers.waf`. Licensed AGPL-3.0.
+
+## Docs
+
+- [Introduction](https://www.caddy-waf.com/introduction): what caddy-waf is, how it sits inside Caddy, and its design goals.
+- [Installation](https://www.caddy-waf.com/installation): building Caddy with the module via xcaddy.
+- [caddy add-package](https://www.caddy-waf.com/add-package-guide): installing the module with `caddy add-package`.
+- [Docker](https://www.caddy-waf.com/docker): running caddy-waf in a container.
+- [Configuration reference](https://www.caddy-waf.com/configuration): every Caddyfile directive and JSON field.
+- [Rules](https://www.caddy-waf.com/rules): the rule schema, scoring, and the anomaly threshold.
+- [Blacklists](https://www.caddy-waf.com/blacklists): IP/CIDR, DNS, country and ASN blacklist file formats.
+- [Rate limiting](https://www.caddy-waf.com/ratelimit): per-IP sliding-window limiter and path scoping.
+- [Country and ASN blocking](https://www.caddy-waf.com/geoblocking): MaxMind-backed geo and ASN filtering.
+- [Client IP and trusted proxies](https://www.caddy-waf.com/client-ip): resolving the real client IP behind proxies.
+- [Dynamic updates](https://www.caddy-waf.com/dynamicupdates): reloading rules and blacklists without a restart.
+
+## Observability
+
+- [Dashboard](https://www.caddy-waf.com/dashboard): the built-in status dashboard.
+- [Metrics](https://www.caddy-waf.com/metrics): the JSON metrics endpoint.
+- [Prometheus and Grafana](https://www.caddy-waf.com/prometheus): the native Prometheus endpoint and dashboards.
+- [ELK](https://www.caddy-waf.com/caddy-waf-elk): shipping logs to Elasticsearch/Kibana.
+
+## Reference
+
+- [Attack coverage](https://www.caddy-waf.com/attacks): the attack classes the bundled rules address.
+- [Security posture](https://www.caddy-waf.com/security): the module's security model and hardening notes.
+- [Testing](https://www.caddy-waf.com/testing): how the module is tested.
+
+## Optional
+
+- [Source repository](https://github.com/fabriziosalmi/caddy-waf): source code, issues, and releases.
+- [Caddy module page](https://caddyserver.com/docs/modules/http.handlers.waf): the module entry in the Caddy registry.
+- [Changelog](https://github.com/fabriziosalmi/caddy-waf/blob/main/CHANGELOG.md): release history.


### PR DESCRIPTION
Closes the fixable SEO-audit findings on https://www.caddy-waf.com/ (served by GitHub Pages). Verified against the live site before/after building `dist`.

## Findings resolved (7 of 8)

| # | Finding | Fix |
|---|---|---|
| 1 | 1/2 images without `alt` | nav-bar logo now carries `alt="caddy-waf logo"` (object form of `themeConfig.logo`; the bare string rendered `alt=""`) |
| 2 | `rel=canonical` absent | per-page canonical via `transformPageData` |
| 3 | No Schema.org / JSON-LD | `SoftwareApplication` JSON-LD block in `<head>` |
| 4 | `/llms.txt` 404 | `docs/public/llms.txt` (llmstxt.org format) |
| 5 | `/.well-known/security.txt` 404 | `docs/public/.well-known/security.txt` (RFC 9116); confirmed copied into the build output |
| 7 | `<title>` too short (9 chars) | home title → `caddy-waf — Web Application Firewall for Caddy` |
| 8 | `max-image-preview:large` absent | `meta robots` in `<head>` (GitHub Pages cannot send `X-Robots-Tag`) |

## Not fixable from the repo

**#6 HSTS header** — the site is served by GitHub Pages, which does not allow custom response headers and does not send `Strict-Transport-Security` on custom domains. Setting HSTS would require fronting the site with a host that allows headers (e.g. Cloudflare). Left unchanged deliberately, not simulated.

## Verification

All fixes confirmed present in `docs/.vitepress/dist` after `npm run docs:build`; JSON-LD validated with `JSON.parse`. `dist` remains git-ignored — only VitePress sources are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)