### PR TITLE
fix(scripts): fetch the CI Army blocklist over https

### DIFF
--- a/get_blacklisted_ip.py
+++ b/get_blacklisted_ip.py
@@ -6,7 +6,7 @@ from tqdm import tqdm
 # List of blocklist URLs and expected line formats
 blocklist_sources = {
     "Emerging Threats": "https://rules.emergingthreats.net/blockrules/compromised-ips.txt",
-    "CI Army List": "http://cinsscore.com/list/ci-badguys.txt",
+    "CI Army List": "https://cinsscore.com/list/ci-badguys.txt",
     "IPsum": "https://raw.githubusercontent.com/stamparm/ipsum/master/levels/1.txt",
     "BlockList.de": "https://www.blocklist.de/lists/all.txt",
     "Blocklist.de - SSH": "https://www.blocklist.de/lists/ssh.txt",


### PR DESCRIPTION
The `CI Army List` feed in `get_blacklisted_ip.py` was the only blocklist source still fetched over plain `http://`. Since the script writes the fetched IPs into `ip_blacklist.txt` that the WAF enforces, a network attacker on the path could tamper with the list. `https://cinsscore.com/list/ci-badguys.txt` serves the same content (verified HTTP 200), and every other source in the script already uses https.

Surfaced by a slopless lint pass (VBC-034). The other flagged `http://` occurrences were verified to be **deliberate attack payloads** in `caddytest.py` (XXE/RFI fixtures fired at the WAF) and are intentionally left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)